### PR TITLE
AppBar: replace stack & set appBar property

### DIFF
--- a/lib/ui/archive_page.dart
+++ b/lib/ui/archive_page.dart
@@ -52,20 +52,15 @@ class ArchivePage extends StatelessWidget {
       initialFiles: null,
     );
     return Scaffold(
-      body: Stack(children: [
-        Padding(
-          padding: EdgeInsets.only(top: Platform.isAndroid ? 80 : 100),
-          child: gallery,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(50.0),
+        child: GalleryAppBarWidget(
+          appBarType,
+          "archive",
+          _selectedFiles,
         ),
-        SizedBox(
-          height: Platform.isAndroid ? 80 : 100,
-          child: GalleryAppBarWidget(
-            appBarType,
-            "archive",
-            _selectedFiles,
-          ),
-        )
-      ]),
+      ),
+      body: gallery,
     );
   }
 }

--- a/lib/ui/collection_page.dart
+++ b/lib/ui/collection_page.dart
@@ -40,21 +40,16 @@ class CollectionPage extends StatelessWidget {
       initialFiles: initialFiles,
     );
     return Scaffold(
-      body: Stack(children: [
-        Padding(
-          padding: EdgeInsets.only(top: Platform.isAndroid ? 80 : 100),
-          child: gallery,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(50.0),
+        child: GalleryAppBarWidget(
+          appBarType,
+          c.collection.name,
+          _selectedFiles,
+          collection: c.collection,
         ),
-        SizedBox(
-          height: Platform.isAndroid ? 80 : 100,
-          child: GalleryAppBarWidget(
-            appBarType,
-            c.collection.name,
-            _selectedFiles,
-            collection: c.collection,
-          ),
-        )
-      ]),
+      ),
+      body: gallery,
     );
   }
 }

--- a/lib/ui/device_folder_page.dart
+++ b/lib/ui/device_folder_page.dart
@@ -34,23 +34,16 @@ class DeviceFolderPage extends StatelessWidget {
       initialFiles: [folder.thumbnail],
     );
     return Scaffold(
-      body: Stack(
-        children: [
-          Padding(
-            padding: EdgeInsets.only(top: Platform.isAndroid ? 80 : 100),
-            child: gallery,
-          ),
-          SizedBox(
-            height: Platform.isAndroid ? 80 : 100,
-            child: GalleryAppBarWidget(
-              GalleryAppBarType.local_folder,
-              folder.name,
-              _selectedFiles,
-              path: folder.thumbnail.deviceFolder,
-            ),
-          )
-        ],
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(50.0),
+        child: GalleryAppBarWidget(
+          GalleryAppBarType.local_folder,
+          folder.name,
+          _selectedFiles,
+          path: folder.thumbnail.deviceFolder,
+        ),
       ),
+      body: gallery,
     );
   }
 


### PR DESCRIPTION
## Description

## Test Plan
Devices: iPhone 11 Pro, Pixel 4a, & One Plus 5T - verified that 
- [x] App bar is visible, even after scrolling down
- [x] App bar shows correct state when files are selected. 
