### PR TITLE
Fix bug in collection updateDB method

### DIFF
--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -533,7 +533,7 @@ class CollectionsService {
       await _db.insert(collections);
     } catch (e) {
       if (attempt < kMaximumWriteAttempts) {
-        return _updateDB(collections, attempt: attempt++);
+        return _updateDB(collections, attempt: ++attempt);
       } else {
         rethrow;
       }


### PR DESCRIPTION
## Description
title ^
## Test Plan
- Sync was getting stuck in infinite loop when _db.insert fails. After this fix, it fails after given attempts.
