### PR TITLE
Separation of feature request & roadmap links

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -7,7 +7,8 @@ const String kSentryDSN =
     "https://2235e5c99219488ea93da34b9ac1cb68@sentry.ente.io/4";
 const String kSentryDebugDSN =
     "https://ca5e686dd7f149d9bf94e620564cceba@sentry.ente.io/3";
-const String kRoadmapURL = "https://roadmap.ente.io";
+const String kRoadmapURL = "https://roadmap.ente.io/roadmap";
+const String kFeatureRequestURL = "https://roadmap.ente.io";
 const int kMicroSecondsInDay = 86400000000;
 const int kAndroid11SDKINT = 30;
 const int kGalleryLoadStartTime = -8000000000000000; // Wednesday, March 6, 1748

--- a/lib/ui/settings/support_section_widget.dart
+++ b/lib/ui/settings/support_section_widget.dart
@@ -47,6 +47,26 @@ class SupportSectionWidget extends StatelessWidget {
                   final isLoggedIn = Configuration.instance.getToken() != null;
                   final url = isLoggedIn
                       ? endpoint + "?token=" + Configuration.instance.getToken()
+                      : kFeatureRequestURL;
+                  return WebPage("feature request", url);
+                },
+              ),
+            );
+          },
+          child: SettingsTextItem(text: "roadmap", icon: Icons.navigate_next),
+        ),
+        Divider(height: 4),
+        GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (BuildContext context) {
+                  final endpoint = Configuration.instance.getHttpEndpoint() +
+                      "/users/roadmap";
+                  final isLoggedIn = Configuration.instance.getToken() != null;
+                  final url = isLoggedIn
+                      ? endpoint + "?token=" + Configuration.instance.getToken()
                       : kRoadmapURL;
                   return WebPage("roadmap", url);
                 },


### PR DESCRIPTION
Currently, the roadmap link in the support section just launches the feature request page of the Feature Monkey page for ente.io. You have to navigate separately to the actual roadmap making separate links a bit more clear.