### PR TITLE
Set webview bg as transparent

### DIFF
--- a/lib/ui/web_page.dart
+++ b/lib/ui/web_page.dart
@@ -22,8 +22,11 @@ class _WebPageState extends State<WebPage> {
         title: Text(widget.title),
         actions: [_hasLoadedPage ? Container() : loadWidget],
       ),
+      backgroundColor: Colors.transparent,
       body: InAppWebView(
         initialUrlRequest: URLRequest(url: Uri.parse(widget.url)),
+        initialOptions: InAppWebViewGroupOptions(
+            crossPlatform: InAppWebViewOptions(transparentBackground: true)),
         onLoadStop: (c, url) {
           setState(() {
             _hasLoadedPage = true;


### PR DESCRIPTION
## Description

According to the documentation for  **transparentBackground**

> Set to `true` to make the background of the WebView transparent. If your app has a dark theme, this can prevent a white flash on initialization. The default value is `false`.

## Test Plan
