### PR TITLE
Update warning dialog when "Hide from recents" is enabled

### DIFF
--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -217,7 +217,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: const [
               Text(
-                "Hiding from the task switcher will prevent you from taking screenshots in this app.",
+                "Hiding from the task switcher may prevent you from taking screenshots in this app.",
                 style: TextStyle(
                   height: 1.5,
                 ),


### PR DESCRIPTION
Not all ROMs may block capturing of screenshots once FLAG_SECURE is set, so update the copy to reflect the same

Fixes #708 
