### PR TITLE
Support for creating link for selected files

### DIFF
--- a/lib/models/collection.dart
+++ b/lib/models/collection.dart
@@ -58,6 +58,10 @@ class Collection {
     return (magicMetadata.subType ?? 0) == subTypeDefaultHidden;
   }
 
+  bool isSharedFilesCollection() {
+    return (magicMetadata.subType ?? 0) == subTypeSharedFilesCollection;
+  }
+
   List<User> getSharees() {
     final List<User> result = [];
     if (sharees == null) {

--- a/lib/models/gallery_type.dart
+++ b/lib/models/gallery_type.dart
@@ -80,6 +80,22 @@ extension GalleyTypeExtension on GalleryType {
     }
   }
 
+  bool showCreateLink() {
+    switch (this) {
+      case GalleryType.ownedCollection:
+      case GalleryType.searchResults:
+      case GalleryType.homepage:
+      case GalleryType.favorite:
+      case GalleryType.archive:
+        return true;
+      case GalleryType.hidden:
+      case GalleryType.localFolder:
+      case GalleryType.trash:
+      case GalleryType.sharedCollection:
+        return false;
+    }
+  }
+
   bool showRemoveFromAlbum() {
     switch (this) {
       case GalleryType.ownedCollection:

--- a/lib/models/magic_metadata.dart
+++ b/lib/models/magic_metadata.dart
@@ -7,6 +7,7 @@ const visibilityHidden = 2;
 
 // Collection SubType Constants
 const subTypeDefaultHidden = 1;
+const subTypeSharedFilesCollection = 2;
 
 const magicKeyVisibility = 'visibility';
 // key for collection subType
@@ -76,6 +77,7 @@ class CollectionMagicMetadata {
 
   // null/0 value -> no subType
   // 1 -> DEFAULT_HIDDEN COLLECTION for files hidden individually
+  // 2 -> Collections created for sharing selected files
   int? subType;
 
   CollectionMagicMetadata({required this.visibility, this.subType});
@@ -86,6 +88,10 @@ class CollectionMagicMetadata {
       result[subTypeKey] = subType!;
     }
     return result;
+  }
+
+  bool isSharedLinkCollection() {
+    return subType != null && subType == subTypeSharedFilesCollection;
   }
 
   factory CollectionMagicMetadata.fromEncodedJson(String encodedJson) =>

--- a/lib/models/magic_metadata.dart
+++ b/lib/models/magic_metadata.dart
@@ -90,10 +90,6 @@ class CollectionMagicMetadata {
     return result;
   }
 
-  bool isSharedLinkCollection() {
-    return subType != null && subType == subTypeSharedFilesCollection;
-  }
-
   factory CollectionMagicMetadata.fromEncodedJson(String encodedJson) =>
       CollectionMagicMetadata.fromJson(jsonDecode(encodedJson));
 

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -9,6 +9,7 @@ import 'package:photos/services/user_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/payment/subscription.dart';
+import 'package:photos/utils/date_time_util.dart';
 import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/email_util.dart';
 import 'package:photos/utils/share_util.dart';
@@ -73,7 +74,8 @@ class CollectionActions {
       // create album with emptyName, use collectionCreationTime on UI to
       // show name
       logger.finest("creating album for sharing files");
-      final collection = await collectionsService.createAlbum("");
+      final String dummyName = " ${getDateAndMonthAndYear(DateTime.now())} ";
+      final collection = await collectionsService.createAlbum(dummyName);
       logger.finest("adding files to share to new album");
       await collectionsService.addToCollection(collection.id, files);
       logger.finest("creating public link for the newly created album");

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/ente_theme_data.dart';
+import 'package:photos/models/api/collection/create_request.dart';
 import 'package:photos/models/collection.dart';
 import 'package:photos/models/file.dart';
+import 'package:photos/models/magic_metadata.dart';
 import 'package:photos/services/collections_service.dart';
+import 'package:photos/services/hidden_service.dart';
 import 'package:photos/services/user_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/common/dialogs.dart';
@@ -84,7 +87,16 @@ class CollectionActions {
         fileWithMinCreationTime.creationTime!,
         fileWithMaxCreationTime.creationTime!,
       );
-      final collection = await collectionsService.createAlbum(dummyName);
+      final CreateRequest req =
+          await collectionsService.buildCollectionCreateRequest(
+        dummyName,
+        visibility: visibilityVisible,
+        subType: subTypeSharedFilesCollection,
+      );
+      final collection = await collectionsService.createAndCacheCollection(
+        null,
+        createRequest: req,
+      );
       logger.finest("adding files to share to new album");
       await collectionsService.addToCollection(collection.id, files);
       logger.finest("creating public link for the newly created album");

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/ente_theme_data.dart';
 import 'package:photos/models/collection.dart';
+import 'package:photos/models/file.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/user_service.dart';
 import 'package:photos/theme/ente_theme.dart';
@@ -59,6 +60,32 @@ class CollectionActions {
       }
       return false;
     }
+  }
+
+  Future<Collection?> createSharedCollectionLink(
+    BuildContext context,
+    List<File> files,
+  ) async {
+    final dialog =
+        createProgressDialog(context, "Creating link...", isDismissible: true);
+    dialog.show();
+    try {
+      // create album with emptyName, use collectionCreationTime on UI to
+      // show name
+      logger.finest("creating album for sharing files");
+      final collection = await collectionsService.createAlbum("");
+      logger.finest("adding files to share to new album");
+      await collectionsService.addToCollection(collection.id, files);
+      logger.finest("creating public link for the newly created album");
+      await CollectionsService.instance.createShareUrl(collection);
+      dialog.hide();
+      return collection;
+    } catch (e, s) {
+      dialog.hide();
+      showGenericErrorDialog(context);
+      logger.severe("Failing to create link for selected files", e, s);
+    }
+    return null;
   }
 
   // removeParticipant remove the user from a share album

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -74,7 +74,16 @@ class CollectionActions {
       // create album with emptyName, use collectionCreationTime on UI to
       // show name
       logger.finest("creating album for sharing files");
-      final String dummyName = " ${getDateAndMonthAndYear(DateTime.now())} ";
+      final File fileWithMinCreationTime = files.reduce(
+        (a, b) => (a.creationTime ?? 0) < (b.creationTime ?? 0) ? a : b,
+      );
+      final File fileWithMaxCreationTime = files.reduce(
+        (a, b) => (a.creationTime ?? 0) > (b.creationTime ?? 0) ? a : b,
+      );
+      final String dummyName = getNameForDateRange(
+        fileWithMinCreationTime.creationTime!,
+        fileWithMaxCreationTime.creationTime!,
+      );
       final collection = await collectionsService.createAlbum(dummyName);
       logger.finest("adding files to share to new album");
       await collectionsService.addToCollection(collection.id, files);

--- a/lib/ui/collections/collection_item_widget.dart
+++ b/lib/ui/collections/collection_item_widget.dart
@@ -56,7 +56,7 @@ class CollectionItem extends StatelessWidget {
             children: [
               const SizedBox(height: 2),
               Text(
-                c.collection.name ?? "Unnamed",
+                (c.collection.name ?? "Unnamed").trim(),
                 style: enteTextTheme.small,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/lib/ui/collections_gallery_widget.dart
+++ b/lib/ui/collections_gallery_widget.dart
@@ -117,9 +117,7 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
       (e) => (e.collection.isSharedFilesCollection()),
     );
 
-    return favMathResult.matched +
-        potentialSharedLinkCollection.unmatched +
-        potentialSharedLinkCollection.matched;
+    return favMathResult.matched + potentialSharedLinkCollection.unmatched;
   }
 
   Widget _getCollectionsGalleryWidget(

--- a/lib/ui/collections_gallery_widget.dart
+++ b/lib/ui/collections_gallery_widget.dart
@@ -114,12 +114,12 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
     // during create link flow for selected files
     final ListMatch<CollectionWithThumbnail> potentialSharedLinkCollection =
         favMathResult.unmatched.splitMatch(
-      (e) => (e.collection.isSharedFilesCollection() &&
-          (e.collection.publicURLs?.isNotEmpty ?? false)),
+      (e) => (e.collection.isSharedFilesCollection()),
     );
 
     return favMathResult.matched +
-        potentialSharedLinkCollection.unmatched;
+        potentialSharedLinkCollection.unmatched +
+        potentialSharedLinkCollection.matched;
   }
 
   Widget _getCollectionsGalleryWidget(

--- a/lib/ui/collections_gallery_widget.dart
+++ b/lib/ui/collections_gallery_widget.dart
@@ -114,14 +114,12 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
     // during create link flow for selected files
     final ListMatch<CollectionWithThumbnail> potentialSharedLinkCollection =
         favMathResult.unmatched.splitMatch(
-      (e) => (e.collection.name != null &&
-          (e.collection.name.startsWith(" ") &&
-              e.collection.name.endsWith(" "))),
+      (e) => (e.collection.isSharedFilesCollection() &&
+          (e.collection.publicURLs?.isNotEmpty ?? false)),
     );
 
     return favMathResult.matched +
-        potentialSharedLinkCollection.unmatched +
-        potentialSharedLinkCollection.matched;
+        potentialSharedLinkCollection.unmatched;
   }
 
   Widget _getCollectionsGalleryWidget(

--- a/lib/ui/collections_gallery_widget.dart
+++ b/lib/ui/collections_gallery_widget.dart
@@ -83,10 +83,18 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
   Future<List<CollectionWithThumbnail>> _getCollections() async {
     final List<CollectionWithThumbnail> collectionsWithThumbnail =
         await CollectionsService.instance.getCollectionsWithThumbnails();
-    final result = collectionsWithThumbnail.splitMatch(
+    final ListMatch<CollectionWithThumbnail> favMathResult =
+        collectionsWithThumbnail.splitMatch(
       (element) => element.collection.type == CollectionType.favorites,
     );
-    result.unmatched.sort(
+    // Hide fav collection if it's empty and not shared
+    favMathResult.matched.removeWhere(
+      (element) =>
+          element.thumbnail == null &&
+          (element.collection.publicURLs?.isEmpty ?? false),
+    );
+
+    favMathResult.unmatched.sort(
       (first, second) {
         if (sortKey == AlbumSortKey.albumName) {
           return compareAsciiLowerCaseNatural(
@@ -102,12 +110,18 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
         }
       },
     );
-    result.matched.removeWhere(
-      (element) =>
-          element.thumbnail == null &&
-          (element.collection.publicURLs?.isEmpty ?? false),
+    // This is a way to identify collection which were automatically created
+    // during create link flow for selected files
+    final ListMatch<CollectionWithThumbnail> potentialSharedLinkCollection =
+        favMathResult.unmatched.splitMatch(
+      (e) => (e.collection.name != null &&
+          (e.collection.name.startsWith(" ") &&
+              e.collection.name.endsWith(" "))),
     );
-    return result.matched + result.unmatched;
+
+    return favMathResult.matched +
+        potentialSharedLinkCollection.unmatched +
+        potentialSharedLinkCollection.matched;
   }
 
   Widget _getCollectionsGalleryWidget(

--- a/lib/ui/components/action_sheet_widget.dart
+++ b/lib/ui/components/action_sheet_widget.dart
@@ -14,7 +14,34 @@ enum ActionSheetType {
   iconOnly,
 }
 
-Future<dynamic> showActionSheet({
+Future<ButtonAction?> showCommonActionSheet({
+  required BuildContext context,
+  required List<ButtonWidget> buttons,
+  required ActionSheetType actionSheetType,
+  bool isCheckIconGreen = false,
+  String? title,
+  String? body,
+}) {
+  return showMaterialModalBottomSheet(
+    backgroundColor: Colors.transparent,
+    barrierColor: backdropFaintDark,
+    useRootNavigator: true,
+    context: context,
+    builder: (_) {
+      return ActionSheetWidget(
+        title: title,
+        body: body,
+        actionButtons: buttons,
+        actionSheetType: actionSheetType,
+        isCheckIconGreen: isCheckIconGreen,
+      );
+    },
+    isDismissible: false,
+    enableDrag: false,
+  );
+}
+
+Future<ButtonAction?> showActionSheet({
   required BuildContext context,
   required List<ButtonWidget> buttons,
   required ActionSheetType actionSheetType,

--- a/lib/ui/create_collection_page.dart
+++ b/lib/ui/create_collection_page.dart
@@ -202,6 +202,11 @@ class _CreateCollectionPageState extends State<CreateCollectionPage> {
       includeCollabCollections:
           widget.actionType == CollectionActionType.addFiles,
     );
+    collectionsWithThumbnail.removeWhere(
+      (element) => (element.collection.type == CollectionType.favorites ||
+          element.collection.type == CollectionType.uncategorized ||
+          element.collection.isSharedFilesCollection()),
+    );
     collectionsWithThumbnail.sort((first, second) {
       return compareAsciiLowerCaseNatural(
         first.collection.name ?? "",

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -73,7 +73,9 @@ class _SharedCollectionGalleryState extends State<SharedCollectionGallery>
           final c =
               CollectionsService.instance.getCollectionByID(file.collectionID);
           if (c.owner.id == Configuration.instance.getUserID()) {
-            if (c.sharees.isNotEmpty || c.publicURLs.isNotEmpty) {
+            if (c.sharees.isNotEmpty ||
+                c.publicURLs.isNotEmpty ||
+                c.isSharedFilesCollection()) {
               outgoing.add(
                 CollectionWithThumbnail(
                   c,

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -91,8 +91,16 @@ class _SharedCollectionGalleryState extends State<SharedCollectionGallery>
           }
         }
         outgoing.sort((first, second) {
-          return second.collection.updationTime
-              .compareTo(first.collection.updationTime);
+          if (second.collection.isSharedFilesCollection() ==
+              first.collection.isSharedFilesCollection()) {
+            return second.collection.updationTime
+                .compareTo(first.collection.updationTime);
+          } else {
+            if (first.collection.isSharedFilesCollection()) {
+              return 1;
+            }
+            return -1;
+          }
         });
         incoming.sort((first, second) {
           return second.collection.updationTime

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -102,14 +102,25 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
     final List<BlurMenuItemWidget> secondList = [];
 
     if (widget.type.showCreateLink()) {
-      firstList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.link_outlined,
-          labelText: "Create link$suffix",
-          menuItemColor: colorScheme.fillFaint,
-          onTap: anyUploadedFiles ? _onCreatedSharedLinkClicked : null,
-        ),
-      );
+      if (_cachedCollectionForSharedLink != null && anyUploadedFiles) {
+        firstList.add(
+          BlurMenuItemWidget(
+            leadingIcon: Icons.copy_outlined,
+            labelText: "Copy link",
+            menuItemColor: colorScheme.fillFaint,
+            onTap: anyUploadedFiles ? _copyLink : null,
+          ),
+        );
+      } else {
+        firstList.add(
+          BlurMenuItemWidget(
+            leadingIcon: Icons.link_outlined,
+            labelText: "Create link$suffix",
+            menuItemColor: colorScheme.fillFaint,
+            onTap: anyUploadedFiles ? _onCreatedSharedLinkClicked : null,
+          ),
+        );
+      }
     }
 
     final showUploadIcon = widget.type == GalleryType.localFolder &&
@@ -333,6 +344,13 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
     }
     _cachedCollectionForSharedLink ??= await collectionActions
         .createSharedCollectionLink(context, split.ownedByCurrentUser);
+    await _copyLink();
+    if (mounted) {
+      setState(() => {});
+    }
+  }
+
+  Future<void> _copyLink() async {
     if (_cachedCollectionForSharedLink != null) {
       final String collectionKey = Base58Encode(
         CollectionsService.instance

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -21,8 +21,10 @@ import 'package:photos/ui/components/bottom_action_bar/expanded_menu_widget.dart
 import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/create_collection_page.dart';
+import 'package:photos/ui/sharing/manage_links_widget.dart';
 import 'package:photos/utils/delete_file_util.dart';
 import 'package:photos/utils/magic_util.dart';
+import 'package:photos/utils/navigation_util.dart';
 import 'package:photos/utils/toast_util.dart';
 
 class FileSelectionActionWidget extends StatefulWidget {
@@ -359,10 +361,18 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
           isInAlert: true,
         ),
         const ButtonWidget(
-          labelText: "Done",
+          labelText: "Manage link",
           buttonType: ButtonType.secondary,
           buttonSize: ButtonSize.large,
           buttonAction: ButtonAction.second,
+          shouldStickToDarkTheme: true,
+          isInAlert: true,
+        ),
+        const ButtonWidget(
+          labelText: "Done",
+          buttonType: ButtonType.secondary,
+          buttonSize: ButtonSize.large,
+          buttonAction: ButtonAction.third,
           shouldStickToDarkTheme: true,
           isInAlert: true,
         )
@@ -373,6 +383,12 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
     );
     if (actionResult != null && actionResult == ButtonAction.first) {
       await _copyLink();
+    }
+    if (actionResult != null && actionResult == ButtonAction.second) {
+      routeToPage(
+        context,
+        ManageSharedLinkWidget(collection: _cachedCollectionForSharedLink),
+      );
     }
     if (mounted) {
       setState(() => {});

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -15,8 +15,11 @@ import 'package:photos/services/hidden_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_file_actions.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
+import 'package:photos/ui/components/action_sheet_widget.dart';
 import 'package:photos/ui/components/blur_menu_item_widget.dart';
 import 'package:photos/ui/components/bottom_action_bar/expanded_menu_widget.dart';
+import 'package:photos/ui/components/button_widget.dart';
+import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/create_collection_page.dart';
 import 'package:photos/utils/delete_file_util.dart';
 import 'package:photos/utils/magic_util.dart';
@@ -344,7 +347,33 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
     }
     _cachedCollectionForSharedLink ??= await collectionActions
         .createSharedCollectionLink(context, split.ownedByCurrentUser);
-    await _copyLink();
+    final actionResult = await showActionSheet(
+      context: context,
+      buttons: [
+        const ButtonWidget(
+          labelText: "Copy link",
+          buttonType: ButtonType.neutral,
+          buttonSize: ButtonSize.large,
+          shouldStickToDarkTheme: true,
+          buttonAction: ButtonAction.first,
+          isInAlert: true,
+        ),
+        const ButtonWidget(
+          labelText: "Done",
+          buttonType: ButtonType.secondary,
+          buttonSize: ButtonSize.large,
+          buttonAction: ButtonAction.second,
+          shouldStickToDarkTheme: true,
+          isInAlert: true,
+        )
+      ],
+      title: "Public link created",
+      body: "You can manage your links in the share tab.",
+      actionSheetType: ActionSheetType.defaultActionSheet,
+    );
+    if (actionResult != null && actionResult == ButtonAction.first) {
+      await _copyLink();
+    }
     if (mounted) {
       setState(() => {});
     }
@@ -359,7 +388,7 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
       final String url =
           "${_cachedCollectionForSharedLink!.publicURLs?.first?.url}#$collectionKey";
       await Clipboard.setData(ClipboardData(text: url));
-      showToast(context, "Link copied to clipboard");
+      showShortToast(context, "Link copied to clipboard");
     }
   }
 

--- a/lib/utils/date_time_util.dart
+++ b/lib/utils/date_time_util.dart
@@ -86,6 +86,32 @@ String getDateAndMonthAndYear(DateTime dateTime) {
       dateTime.year.toString();
 }
 
+// Create link default names:
+// Same day: "Dec 19, 2022"
+// Same month: "Dec 19 - 22, 2022"
+// Base case: "Dec 19, 2022 - Jan 7, 2023"
+String getNameForDateRange(int firstCreationTime, int secondCreationTime) {
+  final startTime = DateTime.fromMicrosecondsSinceEpoch(firstCreationTime);
+  final endTime = DateTime.fromMicrosecondsSinceEpoch(secondCreationTime);
+  // different year
+  if (startTime.year != endTime.year) {
+    return "${_months[startTime.month]!} ${startTime.day}, ${startTime.year} - "
+        "${_months[endTime.month]!} ${endTime.day}, ${endTime.year}";
+  }
+  // same year, diff month
+  if (startTime.month != endTime.month) {
+    return "${_months[startTime.month]!} ${startTime.day} - "
+        "${_months[endTime.month]!} ${endTime.day}, ${endTime.year}";
+  }
+  // same month and year, diff day
+  if (startTime.day != endTime.day) {
+    return "${_months[startTime.month]!} ${startTime.day} - "
+        "${_months[endTime.month]!} ${endTime.day}, ${endTime.year}";
+  }
+  // same day
+  return "${_months[endTime.month]!} ${endTime.day}, ${endTime.year}";
+}
+
 String getDay(DateTime dateTime) {
   return _days[dateTime.weekday]!;
 }


### PR DESCRIPTION
## Description
- For link creation, we are creating collections with special subType (value: 2). 
- The underlying collection's subType is converted to normal collection on first instance of rename. 
- By default, these type of collections are shown at the bottom of Gallery inside the "on ente" and "shared with me section" (unless they are renamed)
- These collections are hidden in the list which we render during **Add to, Move To, Unhide to, Restore to** List.

## Test Plan
Tested locally + On TF