### PR TITLE
Tweak gradients

### DIFF
--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -112,14 +112,30 @@ class FavoriteOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Align(
-      alignment: Alignment.bottomLeft,
-      child: Padding(
-        padding: EdgeInsets.only(left: 4, bottom: 4),
-        child: Icon(
-          Icons.favorite_rounded,
-          size: 20,
-          color: Colors.white, // fixed
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.bottomLeft,
+          end: Alignment.center,
+          // background: linear-gradient(73.58deg, rgba(0, 0, 0, 0.3) -6.66%, rgba(255, 255, 255, 0) 44.44%);
+          colors: [
+            Color.fromRGBO(0, 0, 0, 0.2),
+            Color.fromRGBO(0, 0, 0, 0.1),
+            Color.fromRGBO(0, 0, 0, 0.0),
+            // Color.fromRGBO(0, 0, 0, 0.3),
+          ],
+          stops: [0, 0.5, 1],
+        ),
+      ),
+      child: const Align(
+        alignment: Alignment.bottomLeft,
+        child: Padding(
+          padding: EdgeInsets.only(left: 4, bottom: 4),
+          child: Icon(
+            Icons.favorite_rounded,
+            size: 22,
+            color: Colors.white, // fixed
+          ),
         ),
       ),
     );

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -32,7 +32,10 @@ class FavoriteOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const BottomLeftOverlayIcon(Icons.favorite_rounded);
+    return const BottomLeftOverlayIcon(
+      Icons.favorite_rounded,
+      baseSize: 22,
+    );
   }
 }
 
@@ -143,9 +146,15 @@ class BottomLeftOverlayIcon extends StatelessWidget {
   /// Overriddable color. Default is a fixed white.
   final Color color;
 
+  /// Overriddable default size. This is just the initial hint, the actual size
+  /// is dynamic based on the widget's width (so that we show smaller icons in
+  /// smaller thumbnails).
+  final double baseSize;
+
   const BottomLeftOverlayIcon(
     this.icon, {
     Key? key,
+    this.baseSize = 24,
     this.color = Colors.white, // fixed
   }) : super(key: key);
 
@@ -154,14 +163,13 @@ class BottomLeftOverlayIcon extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         double inset = 4;
-        double size = 22;
+        double size = baseSize;
 
         if (constraints.hasBoundedWidth) {
-          print(constraints);
           final w = constraints.maxWidth;
-          if (w > 100) {
+          if (w > 120) {
             size = 24;
-          } else if (w < 64) {
+          } else if (w < 75) {
             inset = 3;
             size = 16;
           }

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -151,30 +151,48 @@ class BottomLeftOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.bottomLeft,
-          end: Alignment.center,
-          colors: [
-            Color.fromRGBO(0, 0, 0, 0.14),
-            Color.fromRGBO(0, 0, 0, 0.05),
-            Color.fromRGBO(0, 0, 0, 0.0),
-          ],
-          stops: [0, 0.6, 1],
-        ),
-      ),
-      child: Align(
-        alignment: Alignment.bottomLeft,
-        child: Padding(
-          padding: const EdgeInsets.only(left: 4, bottom: 4),
-          child: Icon(
-            icon,
-            size: 22,
-            color: color,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        double inset = 4;
+        double size = 22;
+
+        if (constraints.hasBoundedWidth) {
+          print(constraints);
+          final w = constraints.maxWidth;
+          if (w > 100) {
+            size = 24;
+          } else if (w < 64) {
+            inset = 3;
+            size = 16;
+          }
+        }
+
+        return Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.bottomLeft,
+              end: Alignment.center,
+              colors: [
+                Color.fromRGBO(0, 0, 0, 0.14),
+                Color.fromRGBO(0, 0, 0, 0.05),
+                Color.fromRGBO(0, 0, 0, 0.0),
+              ],
+              stops: [0, 0.6, 1],
+            ),
           ),
-        ),
-      ),
+          child: Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              padding: EdgeInsets.only(left: inset, bottom: inset),
+              child: Icon(
+                icon,
+                size: size,
+                color: color,
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -23,31 +23,27 @@ class UnSyncedIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          // background: linear-gradient(73.58deg, rgba(0, 0, 0, 0.3) -6.66%, rgba(255, 255, 255, 0) 44.44%);
-          colors: [
-            Color.fromRGBO(255, 255, 255, 0),
-            Colors.transparent,
-            // Color.fromRGBO(0, 0, 0, 0.3),
-          ],
-          stops: [-0.067, 0.445],
-        ),
-      ),
-      child: const Align(
-        alignment: Alignment.bottomLeft,
-        child: Padding(
-          padding: EdgeInsets.only(left: 4, bottom: 4),
-          child: Icon(
-            Icons.cloud_off_outlined,
-            size: 18,
-            color: fixedStrokeMutedWhite,
-          ),
-        ),
-      ),
+    return const BottomLeftOverlayIcon(Icons.cloud_off_outlined);
+  }
+}
+
+class FavoriteOverlayIcon extends StatelessWidget {
+  const FavoriteOverlayIcon({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const BottomLeftOverlayIcon(Icons.favorite_rounded);
+  }
+}
+
+class ArchiveOverlayIcon extends StatelessWidget {
+  const ArchiveOverlayIcon({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const BottomLeftOverlayIcon(
+      Icons.archive_outlined,
+      color: fixedStrokeMutedWhite,
     );
   }
 }
@@ -103,27 +99,6 @@ class OwnerAvatarOverlayIcon extends StatelessWidget {
           thumbnailView: true,
         ),
       ),
-    );
-  }
-}
-
-class FavoriteOverlayIcon extends StatelessWidget {
-  const FavoriteOverlayIcon({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return const BottomLeftOverlayIcon(Icons.favorite_rounded);
-  }
-}
-
-class ArchiveOverlayIcon extends StatelessWidget {
-  const ArchiveOverlayIcon({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return const BottomLeftOverlayIcon(
-      Icons.archive_outlined,
-      color: fixedStrokeMutedWhite,
     );
   }
 }

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -117,10 +117,9 @@ class FavoriteOverlayIcon extends StatelessWidget {
         gradient: LinearGradient(
           begin: Alignment.bottomLeft,
           end: Alignment.center,
-          // background: linear-gradient(73.58deg, rgba(0, 0, 0, 0.3) -6.66%, rgba(255, 255, 255, 0) 44.44%);
           colors: [
             Color.fromRGBO(0, 0, 0, 0.2),
-            Color.fromRGBO(0, 0, 0, 0.1),
+            Color.fromRGBO(0, 0, 0, 0.07),
             Color.fromRGBO(0, 0, 0, 0.0),
             // Color.fromRGBO(0, 0, 0, 0.3),
           ],

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -112,31 +112,7 @@ class FavoriteOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.bottomLeft,
-          end: Alignment.center,
-          colors: [
-            Color.fromRGBO(0, 0, 0, 0.14),
-            Color.fromRGBO(0, 0, 0, 0.05),
-            Color.fromRGBO(0, 0, 0, 0.0),
-          ],
-          stops: [0, 0.6, 1],
-        ),
-      ),
-      child: const Align(
-        alignment: Alignment.bottomLeft,
-        child: Padding(
-          padding: EdgeInsets.only(left: 4, bottom: 4),
-          child: Icon(
-            Icons.favorite_rounded,
-            size: 22,
-            color: Colors.white, // fixed
-          ),
-        ),
-      ),
-    );
+    return const BottomLeftOverlayIcon(Icons.favorite_rounded);
   }
 }
 
@@ -181,6 +157,54 @@ class ArchiveOverlayIcon extends StatelessWidget {
           Icons.archive_outlined,
           size: 20,
           color: fixedStrokeMutedWhite,
+        ),
+      ),
+    );
+  }
+}
+
+// Base variations
+
+/// Icon overlay in the bottom left.
+///
+/// This usually indicates ente specific state of a file, e.g. if it is
+/// favorited/archived.
+class BottomLeftOverlayIcon extends StatelessWidget {
+  final IconData icon;
+
+  /// Overriddable color. Default is a fixed white.
+  final Color color;
+
+  const BottomLeftOverlayIcon(
+    this.icon, {
+    Key? key,
+    this.color = Colors.white, // fixed
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.bottomLeft,
+          end: Alignment.center,
+          colors: [
+            Color.fromRGBO(0, 0, 0, 0.14),
+            Color.fromRGBO(0, 0, 0, 0.05),
+            Color.fromRGBO(0, 0, 0, 0.0),
+          ],
+          stops: [0, 0.6, 1],
+        ),
+      ),
+      child: Align(
+        alignment: Alignment.bottomLeft,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 4, bottom: 4),
+          child: Icon(
+            icon,
+            size: 22,
+            color: color,
+          ),
         ),
       ),
     );

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -118,12 +118,11 @@ class FavoriteOverlayIcon extends StatelessWidget {
           begin: Alignment.bottomLeft,
           end: Alignment.center,
           colors: [
-            Color.fromRGBO(0, 0, 0, 0.2),
-            Color.fromRGBO(0, 0, 0, 0.07),
+            Color.fromRGBO(0, 0, 0, 0.14),
+            Color.fromRGBO(0, 0, 0, 0.05),
             Color.fromRGBO(0, 0, 0, 0.0),
-            // Color.fromRGBO(0, 0, 0, 0.3),
           ],
-          stops: [0, 0.5, 1],
+          stops: [0, 0.6, 1],
         ),
       ),
       child: const Align(

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -116,6 +116,18 @@ class FavoriteOverlayIcon extends StatelessWidget {
   }
 }
 
+class ArchiveOverlayIcon extends StatelessWidget {
+  const ArchiveOverlayIcon({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const BottomLeftOverlayIcon(
+      Icons.archive_outlined,
+      color: fixedStrokeMutedWhite,
+    );
+  }
+}
+
 class TrashedFileOverlayText extends StatelessWidget {
   final TrashFile file;
 
@@ -139,25 +151,6 @@ class TrashedFileOverlayText extends StatelessWidget {
             .textTheme
             .subtitle2!
             .copyWith(color: Colors.white), //same for both themes
-      ),
-    );
-  }
-}
-
-class ArchiveOverlayIcon extends StatelessWidget {
-  const ArchiveOverlayIcon({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return const Align(
-      alignment: Alignment.bottomLeft,
-      child: Padding(
-        padding: EdgeInsets.only(left: 4, bottom: 4),
-        child: Icon(
-          Icons.archive_outlined,
-          size: 20,
-          color: fixedStrokeMutedWhite,
-        ),
       ),
     );
   }

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -23,7 +23,7 @@ class UnSyncedIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const BottomLeftOverlayIcon(Icons.cloud_off_outlined);
+    return const _BottomLeftOverlayIcon(Icons.cloud_off_outlined);
   }
 }
 
@@ -32,7 +32,7 @@ class FavoriteOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const BottomLeftOverlayIcon(
+    return const _BottomLeftOverlayIcon(
       Icons.favorite_rounded,
       baseSize: 22,
     );
@@ -44,7 +44,7 @@ class ArchiveOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const BottomLeftOverlayIcon(
+    return const _BottomLeftOverlayIcon(
       Icons.archive_outlined,
       color: fixedStrokeMutedWhite,
     );
@@ -56,7 +56,7 @@ class LivePhotoOverlayIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const BottomRightOverlayIcon(
+    return const _BottomRightOverlayIcon(
       Icons.album_outlined,
       baseSize: 18,
     );
@@ -133,7 +133,7 @@ class TrashedFileOverlayText extends StatelessWidget {
 ///
 /// This usually indicates ente specific state of a file, e.g. if it is
 /// favorited/archived.
-class BottomLeftOverlayIcon extends StatelessWidget {
+class _BottomLeftOverlayIcon extends StatelessWidget {
   final IconData icon;
 
   /// Overriddable color. Default is a fixed white.
@@ -144,7 +144,7 @@ class BottomLeftOverlayIcon extends StatelessWidget {
   /// smaller thumbnails).
   final double baseSize;
 
-  const BottomLeftOverlayIcon(
+  const _BottomLeftOverlayIcon(
     this.icon, {
     Key? key,
     this.baseSize = 24,
@@ -202,7 +202,7 @@ class BottomLeftOverlayIcon extends StatelessWidget {
 ///
 /// This usually indicates information about the file itself, e.g. whether it is
 /// a live photo, or the duration of the video.
-class BottomRightOverlayIcon extends StatelessWidget {
+class _BottomRightOverlayIcon extends StatelessWidget {
   final IconData icon;
 
   /// Overriddable color. Default is a fixed white.
@@ -213,7 +213,7 @@ class BottomRightOverlayIcon extends StatelessWidget {
   /// smaller thumbnails).
   final double baseSize;
 
-  const BottomRightOverlayIcon(
+  const _BottomRightOverlayIcon(
     this.icon, {
     Key? key,
     this.baseSize = 24,

--- a/lib/ui/viewer/file/file_icons_widget.dart
+++ b/lib/ui/viewer/file/file_icons_widget.dart
@@ -51,6 +51,18 @@ class ArchiveOverlayIcon extends StatelessWidget {
   }
 }
 
+class LivePhotoOverlayIcon extends StatelessWidget {
+  const LivePhotoOverlayIcon({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const BottomRightOverlayIcon(
+      Icons.album_outlined,
+      baseSize: 18,
+    );
+  }
+}
+
 class VideoOverlayIcon extends StatelessWidget {
   const VideoOverlayIcon({Key? key}) : super(key: key);
 
@@ -62,25 +74,6 @@ class VideoOverlayIcon extends StatelessWidget {
         Icons.play_circle_outline,
         size: 40,
         color: Colors.white70,
-      ),
-    );
-  }
-}
-
-class LivePhotoOverlayIcon extends StatelessWidget {
-  const LivePhotoOverlayIcon({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return const Align(
-      alignment: Alignment.bottomRight,
-      child: Padding(
-        padding: EdgeInsets.only(right: 4, bottom: 4),
-        child: Icon(
-          Icons.album_outlined,
-          size: 14,
-          color: Colors.white, // fixed
-        ),
       ),
     );
   }
@@ -192,6 +185,75 @@ class BottomLeftOverlayIcon extends StatelessWidget {
             alignment: Alignment.bottomLeft,
             child: Padding(
               padding: EdgeInsets.only(left: inset, bottom: inset),
+              child: Icon(
+                icon,
+                size: size,
+                color: color,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Icon overlay in the bottom right.
+///
+/// This usually indicates information about the file itself, e.g. whether it is
+/// a live photo, or the duration of the video.
+class BottomRightOverlayIcon extends StatelessWidget {
+  final IconData icon;
+
+  /// Overriddable color. Default is a fixed white.
+  final Color color;
+
+  /// Overriddable default size. This is just the initial hint, the actual size
+  /// is dynamic based on the widget's width (so that we show smaller icons in
+  /// smaller thumbnails).
+  final double baseSize;
+
+  const BottomRightOverlayIcon(
+    this.icon, {
+    Key? key,
+    this.baseSize = 24,
+    this.color = Colors.white, // fixed
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        double inset = 4;
+        double size = baseSize;
+
+        if (constraints.hasBoundedWidth) {
+          final w = constraints.maxWidth;
+          if (w > 120) {
+            size = 24;
+          } else if (w < 75) {
+            inset = 3;
+            size = 16;
+          }
+        }
+
+        return Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.bottomRight,
+              end: Alignment.center,
+              colors: [
+                Color.fromRGBO(0, 0, 0, 0.14),
+                Color.fromRGBO(0, 0, 0, 0.05),
+                Color.fromRGBO(0, 0, 0, 0.0),
+              ],
+              stops: [0, 0.6, 1],
+            ),
+          ),
+          child: Align(
+            alignment: Alignment.bottomRight,
+            child: Padding(
+              padding: EdgeInsets.only(bottom: inset, right: inset),
               child: Icon(
                 icon,
                 size: size,


### PR DESCRIPTION
## Description

Tweak the gradients for the bottom left and right thumbnail icon overlays. Modify Figma to match these too.

These are not all the thumbnail overlay types, there are still some differences with Figma, e.g. the video thumbnail in Figma is different: 

<img width="162" alt="Screenshot 2022-12-20 at 2 12 53 PM" src="https://user-images.githubusercontent.com/24503581/208622597-3d7c7d84-a424-4909-843b-413dcf0cbe54.png">

But those are new types of overlays that can be picked up iteratively. This PR just modifies the existing ones, and also provides lower level abstractions like `_BottomRightOverlayIcon` to hopefully making adding the new ones easier.

## Test Plan

Tested on iOS simulator, with a variety of backgrounds and grid sizes.

<img width="314" alt="Screenshot 2022-12-20 at 12 43 32 PM" src="https://user-images.githubusercontent.com/24503581/208623000-18ac7b3d-ae68-4a5f-93b7-2bee84a98754.png">

<img width="313" alt="Screenshot 2022-12-20 at 12 46 01 PM" src="https://user-images.githubusercontent.com/24503581/208623081-16650571-cb81-4d15-90bc-47e58520e3fd.png">

<img width="317" alt="Screenshot 2022-12-20 at 12 47 12 PM" src="https://user-images.githubusercontent.com/24503581/208623111-73788d1e-10aa-4e58-a62d-de573e46b9a0.png">

<img width="313" alt="Screenshot 2022-12-20 at 12 47 37 PM" src="https://user-images.githubusercontent.com/24503581/208623131-0d40e40f-e845-4980-a834-5d5f590b6b42.png">

<img width="314" alt="Screenshot 2022-12-20 at 2 16 40 PM" src="https://user-images.githubusercontent.com/24503581/208623397-3c91979c-eb71-485f-9436-373fc7331bb0.png">
