### PR TITLE
Used StrokeAlign.outside for button's stroke which matchs figma

### DIFF
--- a/lib/ui/components/action_sheet_widget.dart
+++ b/lib/ui/components/action_sheet_widget.dart
@@ -177,10 +177,7 @@ class ActionButtons extends StatelessWidget {
     final actionButtonsWithSeparators = actionButtons;
     return Column(
       children:
-          //Separator height is 8pts in figma. -2pts here as the action
-          //buttons are 2pts extra in height in code compared to figma because
-          //of the border(1pt top + 1pt bottom) of action buttons.
-          addSeparators(actionButtonsWithSeparators, const SizedBox(height: 6)),
+          addSeparators(actionButtonsWithSeparators, const SizedBox(height: 8)),
     );
   }
 }

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -83,7 +83,6 @@ class ButtonWidget extends StatelessWidget {
     final buttonStyle = CustomButtonStyle(
       //Dummy default values since we need to keep these properties non-nullable
       defaultButtonColor: Colors.transparent,
-      defaultBorderColor: Colors.transparent,
       defaultIconColor: Colors.transparent,
       defaultLabelStyle: textTheme.body,
     );
@@ -162,7 +161,7 @@ class ButtonChildWidget extends StatefulWidget {
 
 class _ButtonChildWidgetState extends State<ButtonChildWidget> {
   late Color buttonColor;
-  late Color borderColor;
+  late Color? borderColor;
   late Color iconColor;
   late TextStyle labelStyle;
   late Color checkIconColor;
@@ -209,7 +208,12 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(4)),
           color: buttonColor,
-          border: Border.all(color: borderColor),
+          border: borderColor != null
+              ? Border.all(
+                  color: borderColor!,
+                  strokeAlign: StrokeAlign.outside,
+                )
+              : null,
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),

--- a/lib/ui/components/models/button_type.dart
+++ b/lib/ui/components/models/button_type.dart
@@ -75,11 +75,14 @@ enum ButtonType {
     return null;
   }
 
-  Color defaultBorderColor(EnteColorScheme colorScheme, ButtonSize buttonSize) {
+  Color? defaultBorderColor(
+    EnteColorScheme colorScheme,
+    ButtonSize buttonSize,
+  ) {
     if (this == ButtonType.tertiaryCritical && buttonSize == ButtonSize.large) {
       return colorScheme.warning700;
     }
-    return Colors.transparent;
+    return null;
   }
 
   //Returning null to fallback to default color

--- a/lib/ui/components/models/custom_button_style.dart
+++ b/lib/ui/components/models/custom_button_style.dart
@@ -4,7 +4,7 @@ class CustomButtonStyle {
   Color defaultButtonColor;
   Color? pressedButtonColor;
   Color? disabledButtonColor;
-  Color defaultBorderColor;
+  Color? defaultBorderColor;
   Color? pressedBorderColor;
   Color? disabledBorderColor;
   Color defaultIconColor;
@@ -19,7 +19,7 @@ class CustomButtonStyle {
     required this.defaultButtonColor,
     this.pressedButtonColor,
     this.disabledButtonColor,
-    required this.defaultBorderColor,
+    this.defaultBorderColor,
     this.pressedBorderColor,
     this.disabledBorderColor,
     required this.defaultIconColor,


### PR DESCRIPTION
## Description

Was not aware of the `StrokeAlign` property in `Border()` which should have been used in the Button component. Have used it now.
