### PR TITLE
Delete account redesign

### DIFF
--- a/lib/ui/account/delete_account_page.dart
+++ b/lib/ui/account/delete_account_page.dart
@@ -100,7 +100,7 @@ class DeleteAccountPage extends StatelessWidget {
                 labelText: "No, delete account",
                 icon: Icons.no_accounts_outlined,
                 onTap: () async => {await _initiateDelete(context)},
-                shouldDisableExecutionStates: true,
+                shouldSurfaceExecutionStates: false,
               )
             ],
           ),

--- a/lib/ui/account/delete_account_page.dart
+++ b/lib/ui/account/delete_account_page.dart
@@ -8,9 +8,9 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/models/delete_account.dart';
 import 'package:photos/services/local_authentication_service.dart';
 import 'package:photos/services/user_service.dart';
-import 'package:photos/ui/common/gradient_button.dart';
 import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/components/dialog_widget.dart';
+import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/utils/crypto_util.dart';
 import 'package:photos/utils/email_util.dart';
 
@@ -74,9 +74,10 @@ class DeleteAccountPage extends StatelessWidget {
               const SizedBox(
                 height: 24,
               ),
-              GradientButton(
-                text: "Yes, send feedback",
-                iconData: Icons.check,
+              ButtonWidget(
+                buttonType: ButtonType.primary,
+                labelText: "Yes, send feedback",
+                icon: Icons.check_outlined,
                 onTap: () async {
                   await sendEmail(
                     context,
@@ -85,41 +86,14 @@ class DeleteAccountPage extends StatelessWidget {
                   );
                 },
               ),
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-              ),
-              InkWell(
-                child: SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    style: OutlinedButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      side: const BorderSide(
-                        color: Colors.redAccent,
-                      ),
-                      padding: const EdgeInsets.symmetric(
-                        vertical: 18,
-                        horizontal: 10,
-                      ),
-                      backgroundColor: Colors.white,
-                    ),
-                    label: const Text(
-                      "No, delete account",
-                      style: TextStyle(
-                        color: Colors.redAccent, // same for both themes
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    onPressed: () async => {await _initiateDelete(context)},
-                    icon: const Icon(
-                      Icons.no_accounts,
-                      color: Colors.redAccent,
-                    ),
-                  ),
-                ),
-              ),
+              const SizedBox(height: 8),
+              ButtonWidget(
+                buttonType: ButtonType.tertiaryCritical,
+                labelText: "No, delete account",
+                icon: Icons.no_accounts_outlined,
+                onTap: () async => {await _initiateDelete(context)},
+                shouldDisableExecutionStates: true,
+              )
             ],
           ),
         ),

--- a/lib/ui/account/delete_account_page.dart
+++ b/lib/ui/account/delete_account_page.dart
@@ -8,6 +8,7 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/models/delete_account.dart';
 import 'package:photos/services/local_authentication_service.dart';
 import 'package:photos/services/user_service.dart';
+import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/components/dialog_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
@@ -21,6 +22,7 @@ class DeleteAccountPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = getEnteColorScheme(context);
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
@@ -49,7 +51,10 @@ class DeleteAccountPage extends StatelessWidget {
               Center(
                 child: Text(
                   "We'll be sorry to see you go. Are you facing some issue?",
-                  style: Theme.of(context).textTheme.subtitle1,
+                  style: Theme.of(context)
+                      .textTheme
+                      .subtitle1
+                      .copyWith(color: colorScheme.textMuted),
                 ),
               ),
               const SizedBox(
@@ -68,7 +73,10 @@ class DeleteAccountPage extends StatelessWidget {
                       text: ", maybe there is a way we can help.",
                     ),
                   ],
-                  style: Theme.of(context).textTheme.subtitle1,
+                  style: Theme.of(context)
+                      .textTheme
+                      .subtitle1
+                      .copyWith(color: colorScheme.textMuted),
                 ),
               ),
               const SizedBox(

--- a/lib/ui/account/delete_account_page.dart
+++ b/lib/ui/account/delete_account_page.dart
@@ -156,7 +156,7 @@ class DeleteAccountPage extends StatelessWidget {
         title: 'Are you sure you want to delete your account?',
         body:
             'Your uploaded data will be scheduled for deletion, and your account'
-            'will be permanently deleted. \n\nThis action is not reversible.',
+            ' will be permanently deleted. \n\nThis action is not reversible.',
         firstButtonLabel: "Delete my account",
         isCritical: true,
         firstButtonOnTap: () async {

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -38,10 +38,11 @@ class ButtonWidget extends StatelessWidget {
   final bool isDisabled;
   final ButtonSize buttonSize;
 
-  ///Setting this flag to true will disable the loading and success states
-  ///of the button. This can be set to true if loading and success states aren't
-  ///required in a particular context
-  final bool shouldDisableExecutionStates;
+  ///Setting this flag to true will restrict the loading and success states of
+  ///the button from surfacing on the UI. The ExecutionState of the button will
+  ///change irrespective of the value of this flag. Only that it won't be
+  ///surfaced on the UI
+  final bool shouldSurfaceExecutionStates;
 
   /// iconColor should only be specified when we do not want to honor the default
   /// iconColor based on buttonType. Most of the items, default iconColor is what
@@ -70,7 +71,7 @@ class ButtonWidget extends StatelessWidget {
     this.buttonAction,
     this.isInAlert = false,
     this.iconColor,
-    this.shouldDisableExecutionStates = false,
+    this.shouldSurfaceExecutionStates = true,
     super.key,
   });
 
@@ -135,7 +136,7 @@ class ButtonWidget extends StatelessWidget {
       labelText: labelText,
       icon: icon,
       buttonAction: buttonAction,
-      shouldDisableExecutionStates: shouldDisableExecutionStates,
+      shouldSurfaceExecutionStates: shouldSurfaceExecutionStates,
     );
   }
 }
@@ -150,14 +151,14 @@ class ButtonChildWidget extends StatefulWidget {
   final ButtonSize buttonSize;
   final ButtonAction? buttonAction;
   final bool isInAlert;
-  final bool shouldDisableExecutionStates;
+  final bool shouldSurfaceExecutionStates;
   const ButtonChildWidget({
     required this.buttonStyle,
     required this.buttonType,
     required this.isDisabled,
     required this.buttonSize,
     required this.isInAlert,
-    required this.shouldDisableExecutionStates,
+    required this.shouldSurfaceExecutionStates,
     this.onTap,
     this.labelText,
     this.icon,
@@ -231,7 +232,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
               switchInCurve: Curves.easeInOutExpo,
               switchOutCurve: Curves.easeInOutExpo,
               child: executionState == ExecutionState.idle ||
-                      widget.shouldDisableExecutionStates
+                      !widget.shouldSurfaceExecutionStates
                   ? widget.buttonType.hasTrailingIcon
                       ? Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -341,7 +342,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
   bool get _shouldRegisterGestures =>
       !widget.isDisabled &&
       (executionState == ExecutionState.idle ||
-          widget.shouldDisableExecutionStates);
+          !widget.shouldSurfaceExecutionStates);
 
   void _onTap() async {
     if (widget.onTap != null) {

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -38,6 +38,11 @@ class ButtonWidget extends StatelessWidget {
   final bool isDisabled;
   final ButtonSize buttonSize;
 
+  ///Setting this flag to true will disable the loading and success states
+  ///of the button. This can be set to true if loading and success states aren't
+  ///required in a particular context
+  final bool shouldDisableExecutionStates;
+
   /// iconColor should only be specified when we do not want to honor the default
   /// iconColor based on buttonType. Most of the items, default iconColor is what
   /// we need unless we want to pop out the icon in a non-primary button type
@@ -65,6 +70,7 @@ class ButtonWidget extends StatelessWidget {
     this.buttonAction,
     this.isInAlert = false,
     this.iconColor,
+    this.shouldDisableExecutionStates = false,
     super.key,
   });
 
@@ -129,6 +135,7 @@ class ButtonWidget extends StatelessWidget {
       labelText: labelText,
       icon: icon,
       buttonAction: buttonAction,
+      shouldDisableExecutionStates: shouldDisableExecutionStates,
     );
   }
 }
@@ -143,12 +150,14 @@ class ButtonChildWidget extends StatefulWidget {
   final ButtonSize buttonSize;
   final ButtonAction? buttonAction;
   final bool isInAlert;
+  final bool shouldDisableExecutionStates;
   const ButtonChildWidget({
     required this.buttonStyle,
     required this.buttonType,
     required this.isDisabled,
     required this.buttonSize,
     required this.isInAlert,
+    required this.shouldDisableExecutionStates,
     this.onTap,
     this.labelText,
     this.icon,
@@ -221,7 +230,8 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
               duration: const Duration(milliseconds: 175),
               switchInCurve: Curves.easeInOutExpo,
               switchOutCurve: Curves.easeInOutExpo,
-              child: executionState == ExecutionState.idle
+              child: executionState == ExecutionState.idle ||
+                      widget.shouldDisableExecutionStates
                   ? widget.buttonType.hasTrailingIcon
                       ? Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -329,7 +339,9 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
   }
 
   bool get _shouldRegisterGestures =>
-      !widget.isDisabled && executionState == ExecutionState.idle;
+      !widget.isDisabled &&
+      (executionState == ExecutionState.idle ||
+          widget.shouldDisableExecutionStates);
 
   void _onTap() async {
     if (widget.onTap != null) {

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -38,7 +38,7 @@ class ButtonWidget extends StatelessWidget {
   final bool isDisabled;
   final ButtonSize buttonSize;
 
-  ///Setting this flag to true will restrict the loading and success states of
+  ///Setting this flag to false will restrict the loading and success states of
   ///the button from surfacing on the UI. The ExecutionState of the button will
   ///change irrespective of the value of this flag. Only that it won't be
   ///surfaced on the UI

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -340,9 +340,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
   }
 
   bool get _shouldRegisterGestures =>
-      !widget.isDisabled &&
-      (executionState == ExecutionState.idle ||
-          !widget.shouldSurfaceExecutionStates);
+      !widget.isDisabled && executionState == ExecutionState.idle;
 
   void _onTap() async {
     if (widget.onTap != null) {
@@ -370,7 +368,9 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
       if (executionState == ExecutionState.inProgress) {
         setState(() {
           executionState = ExecutionState.successful;
-          Future.delayed(const Duration(seconds: 2), () {
+          Future.delayed(
+              Duration(seconds: widget.shouldSurfaceExecutionStates ? 2 : 0),
+              () {
             widget.isInAlert
                 ? Navigator.of(context, rootNavigator: true)
                     .pop(widget.buttonAction)

--- a/lib/ui/components/dialog_widget.dart
+++ b/lib/ui/components/dialog_widget.dart
@@ -30,7 +30,7 @@ Future<ButtonAction?> showGenericErrorDialog({
 Future<ButtonAction?> showNewChoiceDialog({
   required BuildContext context,
   required String title,
-  required String body,
+  String? body,
   required String firstButtonLabel,
   String secondButtonLabel = "Cancel",
   ButtonType firstButtonType = ButtonType.neutral,
@@ -63,13 +63,14 @@ Future<ButtonAction?> showNewChoiceDialog({
     title: title,
     body: body,
     buttons: buttons,
+    icon: icon,
   );
 }
 
 Future<ButtonAction?> showDialogWidget({
   required BuildContext context,
   required String title,
-  required String body,
+  String? body,
   required List<ButtonWidget> buttons,
   IconData? icon,
 }) {
@@ -99,13 +100,13 @@ Future<ButtonAction?> showDialogWidget({
 
 class DialogWidget extends StatelessWidget {
   final String title;
-  final String body;
+  final String? body;
   final List<ButtonWidget> buttons;
   final IconData? icon;
   final bool isMobileSmall;
   const DialogWidget({
     required this.title,
-    required this.body,
+    this.body,
     required this.buttons,
     required this.isMobileSmall,
     this.icon,
@@ -147,11 +148,11 @@ class DialogWidget extends StatelessWidget {
 
 class ContentContainer extends StatelessWidget {
   final String title;
-  final String body;
+  final String? body;
   final IconData? icon;
   const ContentContainer({
     required this.title,
-    required this.body,
+    this.body,
     this.icon,
     super.key,
   });
@@ -176,11 +177,13 @@ class ContentContainer extends StatelessWidget {
               ),
         icon == null ? const SizedBox.shrink() : const SizedBox(height: 19),
         Text(title, style: textTheme.h3Bold),
-        const SizedBox(height: 19),
-        Text(
-          body,
-          style: textTheme.body.copyWith(color: colorScheme.textMuted),
-        ),
+        body != null ? const SizedBox(height: 19) : const SizedBox.shrink(),
+        body != null
+            ? Text(
+                body!,
+                style: textTheme.body.copyWith(color: colorScheme.textMuted),
+              )
+            : const SizedBox.shrink(),
       ],
     );
   }

--- a/lib/utils/email_util.dart
+++ b/lib/utils/email_util.dart
@@ -16,6 +16,7 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/core/error-reporting/super_logging.dart';
 import 'package:photos/ente_theme_data.dart';
 import 'package:photos/ui/common/dialogs.dart';
+import 'package:photos/ui/components/dialog_widget.dart';
 import 'package:photos/ui/tools/debug/log_file_viewer.dart';
 import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/toast_util.dart';
@@ -260,7 +261,8 @@ Future<void> sendEmail(
 
 Future<String> _clientInfo() async {
   final packageInfo = await PackageInfo.fromPlatform();
-  final String debugInfo = '\n\n\n\n ------------------- \nFollowing information can '
+  final String debugInfo =
+      '\n\n\n\n ------------------- \nFollowing information can '
       'help us in debugging if you are facing any issue '
       '\nRegistered email: ${Configuration.instance.getEmail()}'
       '\nClient: ${packageInfo.packageName}'
@@ -269,27 +271,15 @@ Future<String> _clientInfo() async {
 }
 
 void _showNoMailAppsDialog(BuildContext context, String toEmail) {
-  showDialog(
+  showNewChoiceDialog(
+    icon: Icons.email_outlined,
     context: context,
-    builder: (context) {
-      return AlertDialog(
-        title: Text('Please email us at $toEmail'),
-        actions: <Widget>[
-          TextButton(
-            child: const Text("Copy email"),
-            onPressed: () async {
-              await Clipboard.setData(ClipboardData(text: toEmail));
-              showShortToast(context, 'Copied');
-            },
-          ),
-          TextButton(
-            child: const Text("OK"),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          )
-        ],
-      );
+    title: 'Please email us at $toEmail',
+    firstButtonLabel: "Copy email address",
+    secondButtonLabel: "Dismiss",
+    firstButtonOnTap: () async {
+      await Clipboard.setData(ClipboardData(text: toEmail));
+      showShortToast(context, 'Copied');
     },
   );
 }


### PR DESCRIPTION
## Description

- Redesigned "Delete account" screen
- Added option to disable success and progress states in UI of buttons when they are not needed. For Example here, the `onTap()` of the "No, delete account" button's execution is still in progress till the last dialog (of title "Are you sure you want to delete your account") is closed and it doesn't make sense to surface execution states on the button as the dialogs show that it is in progress. Note that the execution states _do_ change in the button but it can be restricted from surfacing up on the UI if the `shouldSurfaceExecutionStates` is set to false in `ButtonWidget`.
- Made the 'success' state of `ButtonWidget` as short as possible if the state doesn't have to be surfaced on the UI. This will make the button clickable immediately after the 'progress' state of the button is completed when `shouldSurfaceExecutionState = false`.
 
Before : 

![Simulator Screen Shot - iPhone 12 mini - 2022-12-27 at 12 59 12](https://user-images.githubusercontent.com/77285023/209628995-974c7f54-90d4-49a3-b588-0a9e9f302b70.png)

After : 

![Simulator Screen Shot - iPhone 12 mini - 2022-12-27 at 12 56 32](https://user-images.githubusercontent.com/77285023/209630524-607ec16e-1669-4894-8a91-7322396fbcb5.png)


