### PR TITLE
Add pre-commit hooks to speed-up null-safety migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ You can alternatively install the build from PlayStore or F-Droid.
 1. [Install Flutter](https://flutter.dev/docs/get-started/install)
 2. Clone this repository with `git clone git@github.com:ente-io/photos-app.git`
 3. Pull in all submodules with `git submodule update --init --recursive`
-4. For Android, run `flutter build apk --release --flavor independent`
-5. For iOS, run `flutter build ios`
+4. Enable repo git hooks `git config core.hooksPath hooks`
+5. For Android, run `flutter build apk --release --flavor independent`
+6. For iOS, run `flutter build ios`
 
 <br/>
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+# This git hook fails if a user is trying to add a new file which is
+# not null safe.
+
+# Check the contents of each file that is being added or modified
+for file in `git diff --name-only --cached`; do
+  # Ignore the hooks from any pre-commit check
+  if echo "$file" | grep -q 'hooks/'; then
+    continue
+  fi
+  # Get the contents of the newly added lines in the file
+  newContent=`git diff --cached --unified=0 $file | grep '^+'`
+  oldContent=`git diff --cached --unified=0 $file | grep '^-'`
+  initialContent=`head -5 $file`
+
+  # Check if user has added "// @dart=2.9" in the file
+  if echo "$newContent" | grep -q '// @dart=2.9'; then
+    echo "😡 File $file looks like a newly created file but it's not null-safe"
+    exit 1
+  elif echo "$oldContent" | grep -q '// @dart=2.9'; then
+    echo "💚💚 Thank you for making $file null-safe"
+    continue
+  elif echo "$initialContent" | grep -q '// @dart=2.9'; then
+    echo "🔥🔥🔥🔥 Please make $file null-safe"
+    continue
+  else
+    continue
+  fi
+done
+
+nullUnsafeFiles=$(grep  '// @dart=2.9' -r lib/ | wc -l)
+# The xargs at the end is to trim whitepsaces https://stackoverflow.com/a/12973694/546896
+echo "🥺🥺 $nullUnsafeFiles files are still waiting for their nullSafety migrator" | xargs
+
+# If the script gets to this point, all files passed the check
+exit 0


### PR DESCRIPTION
## Description
This pre-commit hook is just to give constant reminder about our current null-safety migration status. It also blocks creation of any new null-unsafe files and encourage people to migrate any files which they are touching during day to day work.

#### IMPORTANT
Developers need to configure the hooks directory after fetching/merging latest main using following command.

> git config core.hooksPath hooks

## Test Plan

Tested it locally.
