### PR TITLE
Cache 2FA status on on-boarding

### DIFF
--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -279,6 +279,7 @@ class UserService {
         Widget page;
         final String twoFASessionID = response.data["twoFactorSessionID"];
         if (twoFASessionID.isNotEmpty) {
+          setTwoFactor(value: true);
           page = TwoFactorAuthenticationPage(twoFASessionID);
         } else {
           await _saveConfiguration(response);


### PR DESCRIPTION
## Description

Bug : 2FA was only getting fetched on app start if an account is already logged in. So in cases where logging in has to happen, after logging in, the status of the 2FA toggle will be disabled irrespective of the real 2FA status. 

Fix : Set the 2FA status to enabled if the user is required to do 2FA during login. 2FA status is disabled by default.


## Test plan

Tested locally by logging out, logging in, uninstalling the app and logging in and checking the status of 2FA toggle for all cases.
