### PR TITLE
Pass the localizations to the Material App created in AppLock

### DIFF
--- a/lib/ui/tools/app_lock.dart
+++ b/lib/ui/tools/app_lock.dart
@@ -1,8 +1,7 @@
-
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// A widget which handles app lifecycle events for showing and hiding a lock screen.
 /// This should wrap around a `MyApp` widget (or equivalent).
@@ -107,6 +106,8 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
       themeMode: ThemeMode.system,
       theme: widget.lightTheme,
       darkTheme: widget.darkTheme,
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
       onGenerateRoute: (settings) {
         switch (settings.name) {
           case '/lock-screen':


### PR DESCRIPTION
Will be needed in the future when we start accessing the context in showDialog children. For more details, see the sibling auth PR https://github.com/ente-io/auth/pull/29.

## Test Plan

Smoke tested by running the app on iOS simulator.
