### PR TITLE
Increase trailing margin for the theme picker selection checkmark

### DIFF
--- a/lib/ui/components/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget.dart
@@ -22,6 +22,9 @@ class MenuItemWidget extends StatefulWidget {
   final Color? trailingIconColor;
   final Widget? trailingWidget;
   final bool trailingIconIsMuted;
+
+  /// If provided, add this much extra spacing to the right of the trailing icon.
+  final double trailingExtraMargin;
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
   final Color? menuItemColor;
@@ -46,6 +49,7 @@ class MenuItemWidget extends StatefulWidget {
     this.trailingIconColor,
     this.trailingWidget,
     this.trailingIconIsMuted = false,
+    this.trailingExtraMargin = 0.0,
     this.onTap,
     this.onDoubleTap,
     this.menuItemColor,
@@ -177,11 +181,16 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
                   ),
                 )
               : widget.trailingIcon != null
-                  ? Icon(
-                      widget.trailingIcon,
-                      color: widget.trailingIconIsMuted
-                          ? enteColorScheme.strokeMuted
-                          : widget.trailingIconColor,
+                  ? Padding(
+                      padding: EdgeInsets.only(
+                        right: widget.trailingExtraMargin,
+                      ),
+                      child: Icon(
+                        widget.trailingIcon,
+                        color: widget.trailingIconIsMuted
+                            ? enteColorScheme.strokeMuted
+                            : widget.trailingIconColor,
+                      ),
                     )
                   : widget.trailingWidget ?? const SizedBox.shrink(),
         ],

--- a/lib/ui/settings/theme_switch_widget.dart
+++ b/lib/ui/settings/theme_switch_widget.dart
@@ -73,6 +73,7 @@ class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
       pressedColor: getEnteColorScheme(context).fillFaint,
       isExpandable: false,
       trailingIcon: currentThemeMode == themeMode ? Icons.check : null,
+      trailingExtraMargin: 4,
       onTap: () async {
         AdaptiveTheme.of(context).setThemeMode(themeMode);
         currentThemeMode = themeMode;


### PR DESCRIPTION
Before this, the checkmark aligned to the dropdown indicators. This increases the spacing (to match that of the leading text) to indicate that the checkmark is part of the content.

Sibling PR on auth: https://github.com/ente-io/auth/pull/31

Modified Figma also.

## Test Plan

Verified on iOS simulator.

Before / After:

<img width="667" alt="Screenshot 2023-01-08 at 4 44 36 PM" src="https://user-images.githubusercontent.com/24503581/211193169-a8047a62-2da9-414c-9afb-10b138b29dba.png">


