### PR TITLE
Fix logic for computing reset ignore flag on droid

### DIFF
--- a/lib/services/ignored_files_service.dart
+++ b/lib/services/ignored_files_service.dart
@@ -99,6 +99,14 @@ class IgnoredFilesService {
     );
   }
 
+  String? getIgnoredIDForFile(File file) {
+    return _getIgnoreID(
+      file.localID,
+      file.deviceFolder,
+      file.title,
+    );
+  }
+
   // _getIgnoreID will return null if don't have sufficient information
   // to ignore the file based on the platform. Uploads from web or files shared to
   // end usually don't have local id.

--- a/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/lib/ui/viewer/gallery/device_folder_page.dart
@@ -194,12 +194,16 @@ class _BackupHeaderWidgetState extends State<BackupHeaderWidget> {
       Future<List<File>> filesInDeviceCollection) async {
     final List<File> deviceCollectionFiles = await filesInDeviceCollection;
 
-    final localIDsOfFiles = <String>{};
+    final ignoredIdsForFile = <String>{};
     for (File file in deviceCollectionFiles) {
-      localIDsOfFiles.add(file.localID!);
+      final String? ignoreID =
+          IgnoredFilesService.instance.getIgnoredIDForFile(file);
+      if (ignoreID != null) {
+        ignoredIdsForFile.add(ignoreID);
+      }
     }
     final ignoredFiles = await IgnoredFilesService.instance.ignoredIDs;
-    return ignoredFiles.intersection(localIDsOfFiles).isNotEmpty;
+    return ignoredFiles.intersection(ignoredIdsForFile).isNotEmpty;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ description: ente photos application
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 0.7.7+407
+version: 0.7.8+408
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
## Description
Issue: In case of droid, ignored id is actually `'$deviceFolder-$title'`. This is because the media id on android can change for various reasons.

## Test Plan
Tested on droid device
