### PR TITLE
Replace choice dialogs 2

### DIFF
--- a/lib/ui/account/verify_recovery_page.dart
+++ b/lib/ui/account/verify_recovery_page.dart
@@ -12,8 +12,8 @@ import 'package:photos/services/local_authentication_service.dart';
 import 'package:photos/services/user_remote_flag_service.dart';
 import 'package:photos/services/user_service.dart';
 import 'package:photos/ui/account/recovery_key_page.dart';
-import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/common/gradient_button.dart';
+import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/navigation_util.dart';
 
@@ -74,14 +74,15 @@ class _VerifyRecoveryPageState extends State<VerifyRecoveryPage> {
           "The recovery key you entered is not valid. Please make sure it "
           "contains 24 words, and check the spelling of each.\n\nIf you "
           "entered an older recovery code, make sure it is 64 characters long, and check each of them.";
-      final result = await showChoiceDialog(
-        context,
-        "Invalid key",
-        errMessage,
-        firstAction: "Try again",
-        secondAction: "View recovery key",
+      final result = await showNewChoiceDialog(
+        context: context,
+        title: "Invalid key",
+        body: errMessage,
+        firstButtonLabel: "Try again",
+        secondButtonLabel: "View recovery key",
+        secondButtonAction: ButtonAction.second,
       );
-      if (result == DialogUserChoice.secondChoice) {
+      if (result == ButtonAction.second) {
         await _onViewRecoveryKeyClick();
       }
     }

--- a/lib/ui/account/verify_recovery_page.dart
+++ b/lib/ui/account/verify_recovery_page.dart
@@ -75,7 +75,7 @@ class _VerifyRecoveryPageState extends State<VerifyRecoveryPage> {
           "contains 24 words, and check the spelling of each.\n\nIf you "
           "entered an older recovery code, make sure it is 64 characters long, and check each of them.";
       final result = await showNewChoiceDialog(
-        context: context,
+        context,
         title: "Invalid key",
         body: errMessage,
         firstButtonLabel: "Try again",

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -9,8 +9,6 @@ import 'package:photos/models/magic_metadata.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/hidden_service.dart';
 import 'package:photos/services/user_service.dart';
-import 'package:photos/theme/ente_theme.dart';
-import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/payment/subscription.dart';
 import 'package:photos/utils/date_time_util.dart';
@@ -116,32 +114,29 @@ class CollectionActions {
     Collection collection,
     User user,
   ) async {
-    final result = await showChoiceDialog(
+    final result = await showNewChoiceDialog(
       context,
-      "Remove?",
-      "${user.email} will be removed "
-          "from this shared album.\n\nAny photos and videos added by them will also be removed from the album.",
-      firstAction: "Yes, remove",
-      secondAction: "Cancel",
-      secondActionColor: getEnteColorScheme(context).strokeBase,
-      actionType: ActionType.critical,
+      title: "Remove",
+      body: "${user.email} will be removed",
+      firstButtonLabel: "Yes, remove",
+      firstButtonOnTap: () async {
+        try {
+          final newSharees = await CollectionsService.instance
+              .unshare(collection.id, user.email);
+          collection.updateSharees(newSharees);
+        } catch (e, s) {
+          Logger("EmailItemWidget").severe(e, s);
+          rethrow;
+        }
+      },
     );
-    if (result != DialogUserChoice.firstChoice) {
-      return Future.value(null);
-    }
-    final dialog = createProgressDialog(context, "Please wait...");
-    await dialog.show();
-    try {
-      final newSharees =
-          await CollectionsService.instance.unshare(collection.id, user.email);
-      collection.updateSharees(newSharees);
-      await dialog.hide();
-      showShortToast(context, "Stopped sharing with " + user.email + ".");
-      return true;
-    } catch (e, s) {
-      Logger("EmailItemWidget").severe(e, s);
-      await dialog.hide();
+    if (result == ButtonAction.error) {
       await showGenericErrorDialog(context: context);
+      return false;
+    }
+    if (result == ButtonAction.first) {
+      return true;
+    } else {
       return false;
     }
   }

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -11,6 +11,7 @@ import 'package:photos/services/hidden_service.dart';
 import 'package:photos/services/user_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/common/dialogs.dart';
+import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/payment/subscription.dart';
 import 'package:photos/utils/date_time_util.dart';
 import 'package:photos/utils/dialog_util.dart';
@@ -31,15 +32,14 @@ class CollectionActions {
   ) async {
     // confirm if user wants to disable the url
     if (!enable) {
-      final choice = await showChoiceDialog(
+      final choice = await showNewChoiceDialog(
         context,
-        'Remove public link?',
-        'This will remove the public link for accessing "${collection.name}".',
-        firstAction: 'Yes, remove',
-        secondAction: 'Cancel',
-        actionType: ActionType.critical,
+        title: "Remove public link",
+        body:
+            'This will remove the public link for accessing "${collection.name}"',
+        firstButtonLabel: "Yes, remove",
       );
-      if (choice != DialogUserChoice.firstChoice) {
+      if (choice != ButtonAction.first) {
         return false;
       }
     }

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -39,10 +39,10 @@ class ButtonWidget extends StatelessWidget {
   final bool isDisabled;
   final ButtonSize buttonSize;
 
-  ///Setting this flag to true will show a success conformation as a 'check'
+  ///Setting this flag to true will show a success confirmation as a 'check'
   ///icon once the onTap(). This is expected to be used only if time taken to
   ///execute onTap() takes less than debouce time.
-  final bool shouldShowSuccessConformation;
+  final bool shouldShowSuccessConfirmation;
 
   ///Setting this flag to false will restrict the loading and success states of
   ///the button from surfacing on the UI. The ExecutionState of the button will
@@ -84,7 +84,7 @@ class ButtonWidget extends StatelessWidget {
     this.iconColor,
     this.shouldSurfaceExecutionStates = true,
     this.progressStatus,
-    this.shouldShowSuccessConformation = false,
+    this.shouldShowSuccessConfirmation = false,
     super.key,
   });
 
@@ -151,7 +151,7 @@ class ButtonWidget extends StatelessWidget {
       buttonAction: buttonAction,
       shouldSurfaceExecutionStates: shouldSurfaceExecutionStates,
       progressStatus: progressStatus,
-      shouldShowSuccessConformation: shouldShowSuccessConformation,
+      shouldShowSuccessConfirmation: shouldShowSuccessConfirmation,
     );
   }
 }
@@ -168,7 +168,7 @@ class ButtonChildWidget extends StatefulWidget {
   final bool isInAlert;
   final bool shouldSurfaceExecutionStates;
   final ValueNotifier<String>? progressStatus;
-  final bool shouldShowSuccessConformation;
+  final bool shouldShowSuccessConfirmation;
 
   const ButtonChildWidget({
     required this.buttonStyle,
@@ -177,7 +177,7 @@ class ButtonChildWidget extends StatefulWidget {
     required this.buttonSize,
     required this.isInAlert,
     required this.shouldSurfaceExecutionStates,
-    required this.shouldShowSuccessConformation,
+    required this.shouldShowSuccessConfirmation,
     this.progressStatus,
     this.onTap,
     this.labelText,
@@ -399,7 +399,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
         executionState = ExecutionState.error;
         _debouncer.cancelDebounce();
       });
-      widget.shouldShowSuccessConformation && _debouncer.isActive()
+      widget.shouldShowSuccessConfirmation && _debouncer.isActive()
           ? executionState = ExecutionState.successful
           : null;
       _debouncer.cancelDebounce();
@@ -457,7 +457,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
     } else {
       if (widget.isInAlert) {
         Future.delayed(
-          Duration(seconds: widget.shouldShowSuccessConformation ? 1 : 0),
+          Duration(seconds: widget.shouldShowSuccessConfirmation ? 1 : 0),
           () => Navigator.of(context).pop(widget.buttonAction),
         );
       }

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -206,7 +206,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
   ExecutionState executionState = ExecutionState.idle;
 
   @override
-  void initState() {
+  Widget build(BuildContext context) {
     progressStatus = widget.progressStatus;
     checkIconColor = widget.buttonStyle.checkIconColor ??
         widget.buttonStyle.defaultIconColor;
@@ -226,12 +226,6 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
       iconColor = widget.buttonStyle.defaultIconColor;
       labelStyle = widget.buttonStyle.defaultLabelStyle;
     }
-
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
     if (executionState == ExecutionState.successful) {
       Future.delayed(Duration(seconds: widget.isInAlert ? 1 : 2), () {
         setState(() {

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -421,8 +421,13 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
           setState(() {
             executionState = ExecutionState.successful;
             Future.delayed(
-                Duration(seconds: widget.shouldSurfaceExecutionStates ? 2 : 0),
-                () {
+                Duration(
+                  seconds: widget.isInAlert
+                      ? 1
+                      : widget.shouldSurfaceExecutionStates
+                          ? 2
+                          : 0,
+                ), () {
               widget.isInAlert
                   ? Navigator.of(context, rootNavigator: true)
                       .pop(widget.buttonAction)

--- a/lib/ui/payment/child_subscription_widget.dart
+++ b/lib/ui/payment/child_subscription_widget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:photos/ente_theme_data.dart';
+import 'package:logging/logging.dart';
 import 'package:photos/models/user_details.dart';
 import 'package:photos/services/user_service.dart';
-import 'package:photos/ui/common/dialogs.dart';
+import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/utils/dialog_util.dart';
 
 class ChildSubscriptionWidget extends StatelessWidget {
@@ -118,27 +118,22 @@ class ChildSubscriptionWidget extends StatelessWidget {
   }
 
   Future<void> _leaveFamilyPlan(BuildContext context) async {
-    final choice = await showChoiceDialog(
+    final choice = await showNewChoiceDialog(
       context,
-      'Leave family',
-      'Are you sure that you want to leave the family plan?',
-      firstAction: 'No',
-      secondAction: 'Yes',
-      firstActionColor: Theme.of(context).colorScheme.greenAlternative,
-      secondActionColor: Theme.of(context).colorScheme.onSurface,
+      title: "Leave family",
+      body: "Are you sure that you want to leave the family plan?",
+      firstButtonLabel: "Leave",
+      firstButtonOnTap: () async {
+        try {
+          await UserService.instance.leaveFamilyPlan();
+        } catch (e) {
+          Logger("ChildSubscriptionWidget").severe("failed to leave family");
+          rethrow;
+        }
+      },
     );
-    if (choice != DialogUserChoice.secondChoice) {
-      return;
-    }
-    final dialog = createProgressDialog(context, "Please wait...");
-    await dialog.show();
-    try {
-      await UserService.instance.leaveFamilyPlan();
-      await dialog.hide();
-      Navigator.of(context).pop('');
-    } catch (e) {
-      await dialog.hide();
-      showGenericErrorDialog(context: context);
+    if (choice == ButtonAction.error) {
+      await showGenericErrorDialog(context: context);
     }
   }
 }

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -13,6 +13,7 @@ import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/common/loading_widget.dart';
 import 'package:photos/ui/common/progress_dialog.dart';
 import 'package:photos/ui/common/web_page.dart';
+import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/payment/child_subscription_widget.dart';
 import 'package:photos/ui/payment/payment_web_page.dart';
 import 'package:photos/ui/payment/skip_subscription_widget.dart';
@@ -344,24 +345,23 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
       onPressed: () async {
         bool confirmAction = false;
         if (isRenewCancelled) {
-          final choice = await showChoiceDialog(
+          final choice = await showNewChoiceDialog(
             context,
-            title,
-            "Are you sure you want to renew?",
-            firstAction: "No",
-            secondAction: "Yes",
+            title: title,
+            body: "Are you sure you want to renew?",
+            firstButtonLabel: "Yes, Renew",
           );
-          confirmAction = choice == DialogUserChoice.secondChoice;
+          confirmAction = choice == ButtonAction.first;
         } else {
-          final choice = await showChoiceDialog(
+          final choice = await showNewChoiceDialog(
             context,
-            title,
-            'Are you sure you want to cancel?',
-            firstAction: 'Yes, cancel',
-            secondAction: 'No',
-            actionType: ActionType.critical,
+            title: title,
+            body: "Are you sure you want to cancel?",
+            firstButtonLabel: "Yes, cancel",
+            secondButtonLabel: "No",
+            isCritical: true,
           );
-          confirmAction = choice == DialogUserChoice.firstChoice;
+          confirmAction = choice == ButtonAction.first;
         }
         if (confirmAction) {
           toggleStripeSubscription(isRenewCancelled);
@@ -380,7 +380,7 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
     } catch (e) {
       showShortToast(
         context,
-        isRenewCancelled ? 'failed to renew' : 'failed to cancel',
+        isRenewCancelled ? 'Failed to renew' : 'Failed to cancel',
       );
     }
     await _dialog.hide();

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -9,7 +9,6 @@ import 'package:photos/services/billing_service.dart';
 import 'package:photos/services/user_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/common/bottom_shadow.dart';
-import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/common/loading_widget.dart';
 import 'package:photos/ui/common/progress_dialog.dart';
 import 'package:photos/ui/common/web_page.dart';
@@ -430,17 +429,17 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
               String stripPurChaseAction = 'buy';
               if (_isStripeSubscriber && _hasActiveSubscription) {
                 // confirm if user wants to change plan or not
-                final result = await showChoiceDialog(
+                final result = await showNewChoiceDialog(
                   context,
-                  "Confirm plan change",
-                  "Are you sure you want to change your plan?",
-                  firstAction: "No",
-                  secondAction: 'Yes',
+                  title: "Confirm plan change",
+                  body: "Are you sure you want to change your plan?",
+                  firstButtonLabel: "Yes",
                 );
-                if (result != DialogUserChoice.secondChoice) {
+                if (result == ButtonAction.first) {
+                  stripPurChaseAction = 'update';
+                } else {
                   return;
                 }
-                stripPurChaseAction = 'update';
               }
               Navigator.push(
                 context,

--- a/lib/ui/sharing/manage_links_widget.dart
+++ b/lib/ui/sharing/manage_links_widget.dart
@@ -12,7 +12,6 @@ import 'package:photos/services/collections_service.dart';
 import 'package:photos/theme/colors.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
-import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
 import 'package:photos/ui/components/menu_item_widget.dart';
@@ -160,23 +159,6 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                               ?.enableDownload ??
                           true,
                       onChanged: (value) async {
-                        if (!value) {
-                          final choice = await showChoiceDialog(
-                            context,
-                            'Disable downloads',
-                            'Are you sure that you want to disable the download button for files?',
-                            firstAction: 'No',
-                            secondAction: 'Yes',
-                            firstActionColor:
-                                Theme.of(context).colorScheme.greenText,
-                            secondActionColor: Theme.of(context)
-                                .colorScheme
-                                .inverseBackgroundColor,
-                          );
-                          if (choice != DialogUserChoice.secondChoice) {
-                            return;
-                          }
-                        }
                         await _updateUrlSettings(
                           context,
                           {'enableDownload': value},

--- a/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/event_bus.dart';
-import 'package:photos/ente_theme_data.dart';
 import 'package:photos/events/subscription_purchased_event.dart';
 import 'package:photos/models/backup_status.dart';
 import 'package:photos/models/collection.dart';
@@ -19,6 +18,7 @@ import 'package:photos/services/sync_service.dart';
 import 'package:photos/services/update_service.dart';
 import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/common/rename_dialog.dart';
+import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/components/dialog_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/sharing/album_participants_page.dart';
@@ -136,28 +136,20 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
   }
 
   Future<dynamic> _leaveAlbum(BuildContext context) async {
-    final DialogUserChoice? result = await showChoiceDialog(
+    final result = await showNewChoiceDialog(
       context,
-      "Leave shared album?",
-      "You will leave the album, and it will stop being visible to you.",
-      firstAction: "Cancel",
-      secondAction: "Yes, Leave",
-      secondActionColor:
-          Theme.of(context).colorScheme.enteTheme.colorScheme.warning700,
+      title: "Leave shared album",
+      body: "You will leave the album, and it will stop being visible to you",
+      firstButtonLabel: "Yes, leave",
+      isCritical: true,
+      firstButtonOnTap: () async {
+        await CollectionsService.instance.leaveAlbum(widget.collection!);
+        if (mounted) {
+          Navigator.of(context).pop();
+        }
+      },
     );
-    if (result != DialogUserChoice.secondChoice) {
-      return;
-    }
-    final dialog = createProgressDialog(context, "Leaving album...");
-    await dialog.show();
-    try {
-      await CollectionsService.instance.leaveAlbum(widget.collection!);
-      await dialog.hide();
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
-    } catch (e) {
-      await dialog.hide();
+    if (result == ButtonAction.error) {
       showGenericErrorDialog(context: context);
     }
   }

--- a/lib/utils/delete_file_util.dart
+++ b/lib/utils/delete_file_util.dart
@@ -296,28 +296,28 @@ Future<bool> deleteFromTrash(BuildContext context, List<File> files) async {
 }
 
 Future<bool> emptyTrash(BuildContext context) async {
-  final result = await showChoiceDialog(
+  final result = await showNewChoiceDialog(
     context,
-    "Empty trash?",
-    "These files will be permanently removed from your ente account",
-    firstAction: "Empty",
-    actionType: ActionType.critical,
+    title: "Empty trash",
+    firstButtonLabel: "Empty",
+    isCritical: true,
+    firstButtonOnTap: () async {
+      try {
+        await TrashSyncService.instance.emptyTrash();
+      } catch (e, s) {
+        _logger.info("failed empty trash", e, s);
+        rethrow;
+      }
+    },
   );
-  if (result != DialogUserChoice.firstChoice) {
-    return false;
-  }
-  final dialog = createProgressDialog(context, "Please wait...");
-  await dialog.show();
-  try {
-    await TrashSyncService.instance.emptyTrash();
-    showShortToast(context, "Trash emptied");
-    await dialog.hide();
-    return true;
-  } catch (e, s) {
-    _logger.info("failed empty trash", e, s);
-    await dialog.hide();
+  if (result == ButtonAction.error) {
     await showGenericErrorDialog(context: context);
     return false;
+  }
+  if (result == null || result == ButtonAction.cancel) {
+    return false;
+  } else {
+    return true;
   }
 }
 

--- a/lib/utils/email_util.dart
+++ b/lib/utils/email_util.dart
@@ -142,7 +142,7 @@ Future<void> shareLogs(
         onTap: () async {
           await Clipboard.setData(ClipboardData(text: toEmail));
         },
-        shouldShowSuccessConformation: true,
+        shouldShowSuccessConfirmation: true,
       ),
       const ButtonWidget(
         buttonType: ButtonType.neutral,


### PR DESCRIPTION
## Description

- Replaced choice dialogs with the new one.
- Fixed a bug where the theme of ButtonWidget was not changing dynamically when theme is switched.
- Close dialog after 1 second in success state.

Note : Have not added photo/video of all the dialogs.

![Simulator Screen Shot - iPhone 12 mini - 2023-01-07 at 18 25 42](https://user-images.githubusercontent.com/77285023/211494145-983d407c-50e8-4cf8-99e5-c45f57603778.png)

https://user-images.githubusercontent.com/77285023/211494153-da11dc0f-ece0-4b81-b6ff-74d976327f08.mp4

https://user-images.githubusercontent.com/77285023/211494195-56c59b5a-3430-40f7-ba2a-f1c740e12bc6.mp4


https://user-images.githubusercontent.com/77285023/211494377-8d47b8f3-0599-48d3-80af-e8b0e10491ff.mp4



https://user-images.githubusercontent.com/77285023/211494416-45a46286-9efd-48b8-9ca0-ed09693e3654.mp4


![Simulator Screen Shot - iPhone 12 mini - 2023-01-10 at 12 49 17](https://user-images.githubusercontent.com/77285023/211494429-1cc99f18-67a1-409a-8459-3ee2baa30f92.png)


## Test Plan

Tested locally and made sure errors & state of buttons, in dialogs are handled properly.
