### PR TITLE
Fix: Handle null values newer keyAttributes

### DIFF
--- a/lib/core/configuration.dart
+++ b/lib/core/configuration.dart
@@ -374,9 +374,9 @@ class Configuration {
     Uint8List masterKey;
     try {
       masterKey = await CryptoUtil.decrypt(
-        Sodium.base642bin(attributes!.masterKeyEncryptedWithRecoveryKey),
+        Sodium.base642bin(attributes!.masterKeyEncryptedWithRecoveryKey!),
         Sodium.hex2bin(recoveryKey),
-        Sodium.base642bin(attributes.masterKeyDecryptionNonce),
+        Sodium.base642bin(attributes.masterKeyDecryptionNonce!),
       );
     } catch (e) {
       _logger.severe(e);

--- a/lib/core/configuration.dart
+++ b/lib/core/configuration.dart
@@ -273,8 +273,8 @@ class Configuration {
     final kek = await CryptoUtil.deriveKey(
       utf8.encode(password) as Uint8List,
       Sodium.base642bin(attributes.kekSalt),
-      attributes.memLimit,
-      attributes.opsLimit,
+      attributes.memLimit!,
+      attributes.opsLimit!,
     ).onError((e, s) {
       _logger.severe('deriveKey failed', e, s);
       throw KeyDerivationError();
@@ -318,8 +318,8 @@ class Configuration {
     final kek = await CryptoUtil.deriveKey(
       utf8.encode(password) as Uint8List,
       Sodium.base642bin(attributes.kekSalt),
-      attributes.memLimit,
-      attributes.opsLimit,
+      attributes.memLimit!,
+      attributes.opsLimit!,
     ).onError((e, s) {
       _logger.severe('deriveKey failed', e, s);
       throw KeyDerivationError();

--- a/lib/models/key_attributes.dart
+++ b/lib/models/key_attributes.dart
@@ -9,8 +9,8 @@ class KeyAttributes {
   final String secretKeyDecryptionNonce;
   final int? memLimit;
   final int? opsLimit;
-  final String masterKeyEncryptedWithRecoveryKey;
-  final String masterKeyDecryptionNonce;
+  final String? masterKeyEncryptedWithRecoveryKey;
+  final String? masterKeyDecryptionNonce;
   final String? recoveryKeyEncryptedWithMasterKey;
   final String? recoveryKeyDecryptionNonce;
 

--- a/lib/models/key_attributes.dart
+++ b/lib/models/key_attributes.dart
@@ -7,8 +7,8 @@ class KeyAttributes {
   final String publicKey;
   final String encryptedSecretKey;
   final String secretKeyDecryptionNonce;
-  final int memLimit;
-  final int opsLimit;
+  final int? memLimit;
+  final int? opsLimit;
   final String masterKeyEncryptedWithRecoveryKey;
   final String masterKeyDecryptionNonce;
   final String? recoveryKeyEncryptedWithMasterKey;

--- a/lib/models/key_attributes.dart
+++ b/lib/models/key_attributes.dart
@@ -7,8 +7,18 @@ class KeyAttributes {
   final String publicKey;
   final String encryptedSecretKey;
   final String secretKeyDecryptionNonce;
+
+  // Note: For users who signed in before we started storing memLimit and
+  // optsLimit, these fields will be null. To update these values, they need to
+  // either log in again or client needs to fetch these values from server.
+  // (internal monologue: Hopefully, the mem/ops limit used to generate the
+  // key is same as it's stored on the server)
+  // https://github.com/ente-io/photos-app/commit/8cb7f885b343f2c796e4cc9ce1f7d70c9a13a003#diff-02f19d9ee0a60ee9674372d2c780da5d5284128dc9ea65dec6cdcddfc559ebb3
   final int? memLimit;
   final int? opsLimit;
+  // The recovery key attributes can be null for old users who haven't generated
+  // their recovery keys yet.
+  // https://github.com/ente-io/photos-app/commit/d7acc95855c62ecdf2a29c4102e648105e17bd8c#diff-02f19d9ee0a60ee9674372d2c780da5d5284128dc9ea65dec6cdcddfc559ebb3
   final String? masterKeyEncryptedWithRecoveryKey;
   final String? masterKeyDecryptionNonce;
   final String? recoveryKeyEncryptedWithMasterKey;

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -414,8 +414,8 @@ class UserService {
   Future<void> setRecoveryKey(KeyAttributes keyAttributes) async {
     try {
       final setRecoveryKeyRequest = SetRecoveryKeyRequest(
-        keyAttributes.masterKeyEncryptedWithRecoveryKey,
-        keyAttributes.masterKeyDecryptionNonce,
+        keyAttributes.masterKeyEncryptedWithRecoveryKey!,
+        keyAttributes.masterKeyDecryptionNonce!,
         keyAttributes.recoveryKeyEncryptedWithMasterKey!,
         keyAttributes.recoveryKeyDecryptionNonce!,
       );

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -397,8 +397,8 @@ class UserService {
         kekSalt: keyAttributes.kekSalt,
         encryptedKey: keyAttributes.encryptedKey,
         keyDecryptionNonce: keyAttributes.keyDecryptionNonce,
-        memLimit: keyAttributes.memLimit,
-        opsLimit: keyAttributes.opsLimit,
+        memLimit: keyAttributes.memLimit!,
+        opsLimit: keyAttributes.opsLimit!,
       );
       await _enteDio.put(
         "/users/keys",

--- a/lib/utils/validator_util.dart
+++ b/lib/utils/validator_util.dart
@@ -25,7 +25,10 @@ void validatePreVerificationStateCheck(
     "secretKeyDecryptionNonce",
   );
   nullOrEmptyArgCheck(keyAttr.publicKey, "publicKey");
-  if (keyAttr.memLimit <= 0 || keyAttr.opsLimit <= 0) {
+  if (keyAttr.memLimit == null || keyAttr.opsLimit == null) {
+    throw ArgumentError("Key mem/OpsLimit can not be null");
+  }
+  if (keyAttr.memLimit! <= 0 || keyAttr.opsLimit! <= 0) {
     throw ArgumentError("Key mem/OpsLimit can not be <0");
   }
   // check password encoding issues


### PR DESCRIPTION
These attributes were added after the initial launch of the app

- https://github.com/ente-io/photos-app/commit/8cb7f885b343f2c796e4cc9ce1f7d70c9a13a003
- https://github.com/ente-io/photos-app/commit/d7acc95855c62ecdf2a29c4102e648105e17bd8c

**Test Plan**
- Verified that back up are working fine after adding this.
For testing, while reading from map, I changed the map key from `memLimit` to `memDummyLimit`, same for opsLimit.


Note: Change password/ update password flow will be still broken for such users. Keeping the fix for that out of scope of this change, which will fix syncing.