### PR TITLE
Reduce noisy errors on Sentry

### DIFF
--- a/lib/core/errors.dart
+++ b/lib/core/errors.dart
@@ -23,6 +23,17 @@ class SilentlyCancelUploadsError extends Error {}
 
 class UserCancelledUploadError extends Error {}
 
+bool isHandledSyncError(Object errObj) {
+  if (errObj is UnauthorizedError ||
+      errObj is NoActiveSubscriptionError ||
+      errObj is WiFiUnavailableError ||
+      errObj is StorageLimitExceededError ||
+      errObj is SyncStopRequestedError) {
+    return true;
+  }
+  return false;
+}
+
 class LockAlreadyAcquiredError extends Error {}
 
 class UnauthorizedError extends Error {}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:photos/app.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/error-reporting/super_logging.dart';
+import 'package:photos/core/errors.dart';
 import 'package:photos/core/network.dart';
 import 'package:photos/db/upload_locks_db.dart';
 import 'package:photos/ente_theme_data.dart';
@@ -171,7 +172,9 @@ Future<void> _sync(String caller) async {
   try {
     await SyncService.instance.sync();
   } catch (e, s) {
-    _logger.severe("Sync error", e, s);
+    if (!isHandledSyncError(e)) {
+      _logger.severe("Sync error", e, s);
+    }
   }
 }
 

--- a/lib/services/favorites_service.dart
+++ b/lib/services/favorites_service.dart
@@ -131,7 +131,7 @@ class FavoritesService {
       await _collectionsService.addToCollection(collectionID, files);
     }
     _updateFavoriteFilesCache(files, favFlag: true);
-    RemoteSyncService.instance.sync(silently: true);
+    RemoteSyncService.instance.sync(silently: true).ignore();
   }
 
   Future<void> updateFavorites(List<File> files, bool favFlag) async {

--- a/lib/services/file_magic_service.dart
+++ b/lib/services/file_magic_service.dart
@@ -116,10 +116,10 @@ class FileMagicService {
       // update the state of the selected file. Same file in other collection
       // should be eventually synced after remote sync has completed
       await _filesDB.insertMultiple(files);
-      RemoteSyncService.instance.sync(silently: true);
+      RemoteSyncService.instance.sync(silently: true).ignore();
     } on DioError catch (e) {
       if (e.response != null && e.response!.statusCode == 409) {
-        RemoteSyncService.instance.sync(silently: true);
+        RemoteSyncService.instance.sync(silently: true).ignore();
       }
       rethrow;
     } catch (e, s) {
@@ -184,10 +184,10 @@ class FileMagicService {
 
       // update the state of the selected file. Same file in other collection
       // should be eventually synced after remote sync has completed
-      RemoteSyncService.instance.sync(silently: true);
+      RemoteSyncService.instance.sync(silently: true).ignore();
     } on DioError catch (e) {
       if (e.response != null && e.response!.statusCode == 409) {
-        RemoteSyncService.instance.sync(silently: true);
+        RemoteSyncService.instance.sync(silently: true).ignore();
       }
       rethrow;
     } catch (e, s) {

--- a/lib/services/local_file_update_service.dart
+++ b/lib/services/local_file_update_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
+import 'package:photos/core/errors.dart';
 import 'package:photos/db/file_updation_db.dart';
 import 'package:photos/db/files_db.dart';
 import 'package:photos/extensions/stop_watch.dart';
@@ -124,6 +125,9 @@ class LocalFileUpdateService {
             null,
           );
         }
+        processedIDs.add(file.localID!);
+      } on InvalidFileError {
+        // if we fail to get the file, we can ignore the update
         processedIDs.add(file.localID!);
       } catch (e) {
         _logger.severe("Failed to get file uploadData", e);

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -168,7 +168,7 @@ class SyncService {
     _logger.info("Permission granted " + state.toString());
     await _localSyncService.onPermissionGranted(state);
     Bus.instance.fire(PermissionGrantedEvent());
-    _doSync();
+    _doSync().ignore();
   }
 
   void onFoldersSet(Set<String> paths) {


### PR DESCRIPTION
- ignore errors during unawaited syncs
- Do not log handled sync error on sentry
- LocalfileUpdate: Handle invalid file errors
