### PR TITLE
Dialogs bug fix

### DIFF
--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -71,13 +71,11 @@ class CollectionActions {
     }
     final dialog = createProgressDialog(
       context,
-      enable ? "Creating link..." : "Disabling link...",
+      "Creating link...",
     );
     try {
       await dialog.show();
-      enable
-          ? await CollectionsService.instance.createShareUrl(collection)
-          : await CollectionsService.instance.disableShareUrl(collection);
+      await CollectionsService.instance.createShareUrl(collection);
       dialog.hide();
       return true;
     } catch (e) {

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -50,13 +50,13 @@ class CollectionActions {
           ),
           const ButtonWidget(
             buttonType: ButtonType.secondary,
-            buttonAction: ButtonAction.second,
+            buttonAction: ButtonAction.cancel,
             isInAlert: true,
             shouldStickToDarkTheme: true,
             labelText: "Cancel",
           )
         ],
-        title: "Remove public link?",
+        title: "Remove public link",
         body:
             'This will remove the public link for accessing "${collection.name}".',
       );
@@ -64,8 +64,9 @@ class CollectionActions {
         if (result == ButtonAction.error) {
           showGenericErrorDialog(context: context);
         }
-        // return
         return result == ButtonAction.first;
+      } else {
+        return false;
       }
     }
     final dialog = createProgressDialog(

--- a/lib/ui/components/button_widget.dart
+++ b/lib/ui/components/button_widget.dart
@@ -443,8 +443,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
                       : 0,
                 ), () {
               widget.isInAlert
-                  ? Navigator.of(context, rootNavigator: true)
-                      .pop(widget.buttonAction)
+                  ? _popWithButtonAction(context, widget.buttonAction)
                   : null;
               if (mounted) {
                 setState(() {
@@ -461,9 +460,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
           widget.isInAlert
               ? Future.delayed(
                   const Duration(seconds: 0),
-                  () => Navigator.of(context, rootNavigator: true).pop(
-                    ButtonAction.error,
-                  ),
+                  () => _popWithButtonAction(context, ButtonAction.error),
                 )
               : null;
         });
@@ -472,10 +469,18 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
       if (widget.isInAlert) {
         Future.delayed(
           Duration(seconds: widget.shouldShowSuccessConfirmation ? 1 : 0),
-          () => Navigator.of(context).pop(widget.buttonAction),
+          () => _popWithButtonAction(context, widget.buttonAction),
         );
       }
     }
+  }
+
+  void _popWithButtonAction(BuildContext context, ButtonAction? buttonAction) {
+    Navigator.of(context).canPop()
+        ? Navigator.of(context).pop(
+            buttonAction,
+          )
+        : null;
   }
 
   void _onTapDown(details) {


### PR DESCRIPTION
## Description

- The navigator was getting popped completely if a dialog is closed when it is in loading or success state. This has been fixed.
- On dismissing by tapping outside the dialog which confirms if a public link should be removed, instead of not removing the public link it was in fact removing the public link. This has been fixed.
- Removed some dead code.

## Test Plan

Tested and confirmed that both the bugs are fixed now.
