### PR TITLE
Execution states for MenuItemWidget

### DIFF
--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -363,25 +363,11 @@ class CollectionActions {
     BuildContext context,
     Collection collection,
   ) async {
-    final ButtonAction? result = await showActionSheet(
-      context: context,
-      buttons: [
-        const ButtonWidget(
-          buttonType: ButtonType.critical,
-          isInAlert: true,
-          shouldStickToDarkTheme: true,
-          buttonAction: ButtonAction.first,
-          labelText: "Delete album",
-        ),
-        const ButtonWidget(
-          buttonType: ButtonType.secondary,
-          buttonAction: ButtonAction.cancel,
-          isInAlert: true,
-          shouldStickToDarkTheme: true,
-          labelText: "Cancel",
-        )
-      ],
+    final ButtonAction? result = await showChoiceActionSheet(
+      context,
+      isCritical: true,
       title: "Delete shared album?",
+      firstButtonLabel: "Delete album",
       body: "The album will be deleted for everyone\n\nYou will lose access to "
           "shared photos in this album that are owned by others",
     );

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -36,21 +36,13 @@ class CollectionActions {
     Collection collection, {
     bool enableCollect = false,
   }) async {
-    final dialog = createProgressDialog(
-      context,
-      "Creating link...",
-      isDismissible: true,
-    );
     try {
-      await dialog.show();
       await CollectionsService.instance.createShareUrl(
         collection,
         enableCollect: enableCollect,
       );
-      dialog.hide();
       return true;
     } catch (e) {
-      dialog.hide();
       if (e is SharingNotPermittedForFreeAccountsError) {
         _showUnSupportedAlert(context);
       } else {

--- a/lib/ui/advanced_settings_screen.dart
+++ b/lib/ui/advanced_settings_screen.dart
@@ -6,7 +6,7 @@ import 'package:photos/events/force_reload_home_gallery_event.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/icon_button_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/ui/components/title_bar_widget.dart';
 import 'package:photos/ui/tools/debug/app_storage_viewer.dart';

--- a/lib/ui/advanced_settings_screen.dart
+++ b/lib/ui/advanced_settings_screen.dart
@@ -98,7 +98,7 @@ class _AdvancedSettingsScreenState extends State<AdvancedSettingsScreen> {
                               ),
                               borderRadius: 8,
                               alignCaptionedTextToLeft: true,
-                              onTap: () {
+                              onTap: () async {
                                 routeToPage(context, const AppStorageViewer());
                               },
                             ),

--- a/lib/ui/backup_settings_screen.dart
+++ b/lib/ui/backup_settings_screen.dart
@@ -6,7 +6,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
 import 'package:photos/ui/components/icon_button_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/ui/components/title_bar_widget.dart';

--- a/lib/ui/components/album_list_item_widget.dart
+++ b/lib/ui/components/album_list_item_widget.dart
@@ -37,7 +37,7 @@ class AlbumListItemWidget extends StatelessWidget {
                         ? ThumbnailWidget(
                             item.thumbnail,
                             showFavForAlbumOnly: true,
-                            shouldShowOwnerAvatar: true,
+                            shouldShowOwnerAvatar: false,
                           )
                         : const NoThumbnailWidget(
                             addBorder: false,

--- a/lib/ui/components/expandable_menu_item_widget.dart
+++ b/lib/ui/components/expandable_menu_item_widget.dart
@@ -2,7 +2,7 @@ import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:photos/ente_theme_data.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/ui/settings/inherited_settings_state.dart';
 

--- a/lib/ui/components/menu_item_widget/menu_item_child_widgets.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_child_widgets.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:photos/theme/ente_theme.dart';
+
+class TrailingWidget extends StatefulWidget {
+  final IconData? trailingIcon;
+  final Color? trailingIconColor;
+  final Widget? trailingWidget;
+  final bool trailingIconIsMuted;
+  final double trailingExtraMargin;
+  const TrailingWidget({
+    this.trailingIcon,
+    this.trailingIconColor,
+    this.trailingWidget,
+    required this.trailingIconIsMuted,
+    required this.trailingExtraMargin,
+    super.key,
+  });
+  @override
+  State<TrailingWidget> createState() => _TrailingWidgetState();
+}
+
+class _TrailingWidgetState extends State<TrailingWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = getEnteColorScheme(context);
+    if (widget.trailingIcon != null) {
+      return Padding(
+        padding: EdgeInsets.only(
+          right: widget.trailingExtraMargin,
+        ),
+        child: Icon(
+          widget.trailingIcon,
+          color: widget.trailingIconIsMuted
+              ? colorScheme.strokeMuted
+              : widget.trailingIconColor,
+        ),
+      );
+    } else {
+      return widget.trailingWidget ?? const SizedBox.shrink();
+    }
+  }
+}
+
+class ExpansionTrailingIcon extends StatelessWidget {
+  final bool isExpanded;
+  final IconData? trailingIcon;
+  final Color? trailingIconColor;
+  const ExpansionTrailingIcon({
+    required this.isExpanded,
+    this.trailingIcon,
+    this.trailingIconColor,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 100),
+      curve: Curves.easeInOut,
+      opacity: isExpanded ? 0 : 1,
+      child: AnimatedSwitcher(
+        transitionBuilder: (child, animation) {
+          return ScaleTransition(scale: animation, child: child);
+        },
+        duration: const Duration(milliseconds: 200),
+        switchInCurve: Curves.easeOut,
+        child: isExpanded
+            ? const SizedBox.shrink()
+            : Icon(
+                trailingIcon,
+                color: trailingIconColor,
+              ),
+      ),
+    );
+  }
+}
+
+class LeadingWidget extends StatelessWidget {
+  final IconData? leadingIcon;
+  final Color? leadingIconColor;
+
+  final Widget? leadingIconWidget;
+  // leadIconSize deafult value is 20.
+  final double leadingIconSize;
+  const LeadingWidget({
+    required this.leadingIconSize,
+    this.leadingIcon,
+    this.leadingIconColor,
+    this.leadingIconWidget,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 10),
+      child: SizedBox(
+        height: leadingIconSize,
+        width: leadingIconSize,
+        child: leadingIcon == null
+            ? (leadingIconWidget != null
+                ? FittedBox(
+                    fit: BoxFit.contain,
+                    child: leadingIconWidget,
+                  )
+                : const SizedBox.shrink())
+            : FittedBox(
+                fit: BoxFit.contain,
+                child: Icon(
+                  leadingIcon,
+                  color: leadingIconColor ??
+                      getEnteColorScheme(context).strokeBase,
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/ui/components/menu_item_widget/menu_item_child_widgets.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_child_widgets.dart
@@ -10,6 +10,7 @@ class TrailingWidget extends StatefulWidget {
   final Widget? trailingWidget;
   final bool trailingIconIsMuted;
   final double trailingExtraMargin;
+  final bool showExecutionStates;
   const TrailingWidget({
     required this.executionStateNotifier,
     this.trailingIcon,
@@ -17,6 +18,7 @@ class TrailingWidget extends StatefulWidget {
     this.trailingWidget,
     required this.trailingIconIsMuted,
     required this.trailingExtraMargin,
+    required this.showExecutionStates,
     super.key,
   });
   @override
@@ -27,7 +29,9 @@ class _TrailingWidgetState extends State<TrailingWidget> {
   Widget? trailingWidget;
   @override
   void initState() {
-    widget.executionStateNotifier.addListener(_executionStateListener);
+    widget.showExecutionStates
+        ? widget.executionStateNotifier.addListener(_executionStateListener)
+        : null;
     super.initState();
   }
 
@@ -39,7 +43,7 @@ class _TrailingWidgetState extends State<TrailingWidget> {
 
   @override
   Widget build(BuildContext context) {
-    if (trailingWidget == null) {
+    if (trailingWidget == null || !widget.showExecutionStates) {
       _setTrailingIcon();
     }
     return AnimatedSwitcher(

--- a/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -1,7 +1,7 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
-import 'package:photos/ente_theme_data.dart';
 import 'package:photos/theme/ente_theme.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_child_widgets.dart';
 
 class MenuItemWidget extends StatefulWidget {
   final Widget captionedTextWidget;
@@ -110,7 +110,6 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
   }
 
   Widget menuItemWidget(BuildContext context) {
-    final enteColorScheme = Theme.of(context).colorScheme.enteTheme.colorScheme;
     final borderRadius = Radius.circular(widget.borderRadius);
     final isExpanded = widget.expandableController?.value;
     final bottomBorderRadius =
@@ -138,61 +137,27 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
         children: [
           widget.alignCaptionedTextToLeft && widget.leadingIcon == null
               ? const SizedBox.shrink()
-              : Padding(
-                  padding: const EdgeInsets.only(right: 10),
-                  child: SizedBox(
-                    height: widget.leadingIconSize,
-                    width: widget.leadingIconSize,
-                    child: widget.leadingIcon == null
-                        ? (widget.leadingIconWidget != null
-                            ? FittedBox(
-                                fit: BoxFit.contain,
-                                child: widget.leadingIconWidget,
-                              )
-                            : const SizedBox.shrink())
-                        : FittedBox(
-                            fit: BoxFit.contain,
-                            child: Icon(
-                              widget.leadingIcon,
-                              color: widget.leadingIconColor ??
-                                  enteColorScheme.strokeBase,
-                            ),
-                          ),
-                  ),
+              : LeadingWidget(
+                  leadingIconSize: widget.leadingIconSize,
+                  leadingIcon: widget.leadingIcon,
+                  leadingIconColor: widget.leadingIconColor,
+                  leadingIconWidget: widget.leadingIconWidget,
                 ),
           widget.captionedTextWidget,
-          widget.expandableController != null
-              ? AnimatedOpacity(
-                  duration: const Duration(milliseconds: 100),
-                  curve: Curves.easeInOut,
-                  opacity: isExpanded! ? 0 : 1,
-                  child: AnimatedSwitcher(
-                    transitionBuilder: (child, animation) {
-                      return ScaleTransition(scale: animation, child: child);
-                    },
-                    duration: const Duration(milliseconds: 200),
-                    switchInCurve: Curves.easeOut,
-                    child: isExpanded
-                        ? const SizedBox.shrink()
-                        : Icon(
-                            widget.trailingIcon,
-                            color: widget.trailingIconColor,
-                          ),
-                  ),
-                )
-              : widget.trailingIcon != null
-                  ? Padding(
-                      padding: EdgeInsets.only(
-                        right: widget.trailingExtraMargin,
-                      ),
-                      child: Icon(
-                        widget.trailingIcon,
-                        color: widget.trailingIconIsMuted
-                            ? enteColorScheme.strokeMuted
-                            : widget.trailingIconColor,
-                      ),
-                    )
-                  : widget.trailingWidget ?? const SizedBox.shrink(),
+          if (widget.expandableController != null)
+            ExpansionTrailingIcon(
+              isExpanded: isExpanded!,
+              trailingIcon: widget.trailingIcon,
+              trailingIconColor: widget.trailingIconColor,
+            )
+          else
+            TrailingWidget(
+              trailingIcon: widget.trailingIcon,
+              trailingIconColor: widget.trailingIconColor,
+              trailingWidget: widget.trailingWidget,
+              trailingIconIsMuted: widget.trailingIconIsMuted,
+              trailingExtraMargin: widget.trailingExtraMargin,
+            ),
         ],
       ),
     );

--- a/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -48,6 +48,10 @@ class MenuItemWidget extends StatefulWidget {
   /// disable gesture detector if not used
   final bool isGestureDetectorDisabled;
 
+  ///Success state will not be shown if this flag is set to true, only idle and
+  ///loading state
+  final bool showOnlyLoadingState;
+
   const MenuItemWidget({
     required this.captionedTextWidget,
     this.isExpandable = false,
@@ -70,6 +74,7 @@ class MenuItemWidget extends StatefulWidget {
     this.isBottomBorderRadiusRemoved = false,
     this.isTopBorderRadiusRemoved = false,
     this.isGestureDetectorDisabled = false,
+    this.showOnlyLoadingState = false,
     Key? key,
   }) : super(key: key);
 
@@ -192,10 +197,14 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
         .onError((error, stackTrace) => _debouncer.cancelDebounce());
     _debouncer.cancelDebounce();
     if (executionStateNotifier.value == ExecutionState.inProgress) {
-      executionStateNotifier.value = ExecutionState.successful;
-      Future.delayed(const Duration(seconds: 2), () {
+      if (widget.showOnlyLoadingState) {
         executionStateNotifier.value = ExecutionState.idle;
-      });
+      } else {
+        executionStateNotifier.value = ExecutionState.successful;
+        Future.delayed(const Duration(seconds: 2), () {
+          executionStateNotifier.value = ExecutionState.idle;
+        });
+      }
     }
   }
 

--- a/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -52,6 +52,8 @@ class MenuItemWidget extends StatefulWidget {
   ///loading state
   final bool showOnlyLoadingState;
 
+  final bool surfaceExecutionStates;
+
   const MenuItemWidget({
     required this.captionedTextWidget,
     this.isExpandable = false,
@@ -75,6 +77,7 @@ class MenuItemWidget extends StatefulWidget {
     this.isTopBorderRadiusRemoved = false,
     this.isGestureDetectorDisabled = false,
     this.showOnlyLoadingState = false,
+    this.surfaceExecutionStates = true,
     Key? key,
   }) : super(key: key);
 
@@ -178,6 +181,7 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
               trailingWidget: widget.trailingWidget,
               trailingIconIsMuted: widget.trailingIconIsMuted,
               trailingExtraMargin: widget.trailingExtraMargin,
+              showExecutionStates: widget.surfaceExecutionStates,
               key: ValueKey(widget.trailingIcon.hashCode),
             ),
         ],

--- a/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -54,6 +54,8 @@ class MenuItemWidget extends StatefulWidget {
 
   final bool surfaceExecutionStates;
 
+  final bool alwaysShowSuccessState;
+
   const MenuItemWidget({
     required this.captionedTextWidget,
     this.isExpandable = false,
@@ -78,6 +80,7 @@ class MenuItemWidget extends StatefulWidget {
     this.isGestureDetectorDisabled = false,
     this.showOnlyLoadingState = false,
     this.surfaceExecutionStates = true,
+    this.alwaysShowSuccessState = false,
     Key? key,
   }) : super(key: key);
 
@@ -197,10 +200,21 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
         },
       ),
     );
-    await widget.onTap
-        ?.call()
-        .onError((error, stackTrace) => _debouncer.cancelDebounce());
+    await widget.onTap?.call().then(
+      (value) {
+        widget.alwaysShowSuccessState
+            ? executionStateNotifier.value = ExecutionState.successful
+            : null;
+      },
+      onError: (error, stackTrace) => _debouncer.cancelDebounce(),
+    );
     _debouncer.cancelDebounce();
+    if (widget.alwaysShowSuccessState) {
+      Future.delayed(const Duration(seconds: 2), () {
+        executionStateNotifier.value = ExecutionState.idle;
+      });
+      return;
+    }
     if (executionStateNotifier.value == ExecutionState.inProgress) {
       if (widget.showOnlyLoadingState) {
         executionStateNotifier.value = ExecutionState.idle;

--- a/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -178,6 +178,7 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
               trailingWidget: widget.trailingWidget,
               trailingIconIsMuted: widget.trailingIconIsMuted,
               trailingExtraMargin: widget.trailingExtraMargin,
+              key: ValueKey(widget.trailingIcon.hashCode),
             ),
         ],
       ),

--- a/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -54,6 +54,10 @@ class MenuItemWidget extends StatefulWidget {
 
   final bool surfaceExecutionStates;
 
+  ///To show success state even when execution time < debouce time, set this
+  ///flag to true. If the loading state needs to be shown and success state not,
+  ///set the showOnlyLoadingState flag to true, setting this flag to false won't
+  ///help.
   final bool alwaysShowSuccessState;
 
   const MenuItemWidget({

--- a/lib/ui/components/toggle_switch_widget.dart
+++ b/lib/ui/components/toggle_switch_widget.dart
@@ -9,12 +9,12 @@ enum ExecutionState {
   successful,
 }
 
-typedef FutureVoidCallBack = Future<void> Function();
+typedef FutureVoidCallback = Future<void> Function();
 typedef BoolCallBack = bool Function();
 
 class ToggleSwitchWidget extends StatefulWidget {
   final BoolCallBack value;
-  final FutureVoidCallBack onChanged;
+  final FutureVoidCallback onChanged;
   const ToggleSwitchWidget({
     required this.value,
     required this.onChanged,

--- a/lib/ui/settings/about_section_widget.dart
+++ b/lib/ui/settings/about_section_widget.dart
@@ -113,7 +113,7 @@ class AboutMenuItemWidget extends StatelessWidget {
       pressedColor: getEnteColorScheme(context).fillFaint,
       trailingIcon: Icons.chevron_right_outlined,
       trailingIconIsMuted: true,
-      onTap: () {
+      onTap: () async {
         Navigator.of(context).push(
           MaterialPageRoute(
             builder: (BuildContext context) {

--- a/lib/ui/settings/about_section_widget.dart
+++ b/lib/ui/settings/about_section_widget.dart
@@ -4,7 +4,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/common/web_page.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/app_update_dialog.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/utils/dialog_util.dart';

--- a/lib/ui/settings/account_section_widget.dart
+++ b/lib/ui/settings/account_section_widget.dart
@@ -11,7 +11,7 @@ import 'package:photos/ui/account/password_entry_page.dart';
 import 'package:photos/ui/account/recovery_key_page.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/navigation_util.dart';

--- a/lib/ui/settings/account_section_widget.dart
+++ b/lib/ui/settings/account_section_widget.dart
@@ -128,7 +128,7 @@ class AccountSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
-          onTap: () {
+          onTap: () async {
             _onLogoutTapped(context);
           },
         ),
@@ -140,7 +140,7 @@ class AccountSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
-          onTap: () {
+          onTap: () async {
             routeToPage(context, const DeleteAccountPage());
           },
         ),

--- a/lib/ui/settings/account_section_widget.dart
+++ b/lib/ui/settings/account_section_widget.dart
@@ -39,6 +39,7 @@ class AccountSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
           onTap: () async {
             final hasAuthenticated = await LocalAuthenticationService.instance
                 .requestLocalAuthentication(
@@ -75,6 +76,7 @@ class AccountSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
           onTap: () async {
             final hasAuthenticated = await LocalAuthenticationService.instance
                 .requestLocalAuthentication(
@@ -101,6 +103,7 @@ class AccountSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
           onTap: () async {
             final hasAuthenticated = await LocalAuthenticationService.instance
                 .requestLocalAuthentication(

--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -85,19 +85,16 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
           onTap: () async {
-            final dialog = createProgressDialog(context, "Calculating...");
-            await dialog.show();
             BackupStatus status;
             try {
               status = await SyncService.instance.getBackupStatus();
             } catch (e) {
-              await dialog.hide();
               showGenericErrorDialog(context: context);
               return;
             }
 
-            await dialog.hide();
             if (status.localIDs.isEmpty) {
               showErrorDialog(
                 context,
@@ -121,20 +118,17 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
           onTap: () async {
-            final dialog = createProgressDialog(context, "Calculating...");
-            await dialog.show();
             List<DuplicateFiles> duplicates;
             try {
               duplicates =
                   await DeduplicationService.instance.getDuplicateFiles();
             } catch (e) {
-              await dialog.hide();
               showGenericErrorDialog(context: context);
               return;
             }
 
-            await dialog.hide();
             if (duplicates.isEmpty) {
               showErrorDialog(
                 context,

--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -49,7 +49,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
         pressedColor: getEnteColorScheme(context).fillFaint,
         trailingIcon: Icons.chevron_right_outlined,
         trailingIconIsMuted: true,
-        onTap: () {
+        onTap: () async {
           routeToPage(
             context,
             const BackupFolderSelectionPage(
@@ -66,7 +66,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
         pressedColor: getEnteColorScheme(context).fillFaint,
         trailingIcon: Icons.chevron_right_outlined,
         trailingIconIsMuted: true,
-        onTap: () {
+        onTap: () async {
           routeToPage(
             context,
             const BackupSettingsScreen(),

--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -12,7 +12,7 @@ import 'package:photos/ui/backup_settings_screen.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/dialog_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/ui/tools/deduplicate_page.dart';

--- a/lib/ui/settings/debug_section_widget.dart
+++ b/lib/ui/settings/debug_section_widget.dart
@@ -8,7 +8,7 @@ import 'package:photos/services/update_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/utils/toast_util.dart';
 

--- a/lib/ui/settings/general_section_widget.dart
+++ b/lib/ui/settings/general_section_widget.dart
@@ -34,7 +34,7 @@ class GeneralSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
-          onTap: () {
+          onTap: () async {
             _onManageSubscriptionTapped(context);
           },
         ),
@@ -46,7 +46,7 @@ class GeneralSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
-          onTap: () {
+          onTap: () async {
             _onFamilyPlansTapped(context);
           },
         ),
@@ -58,7 +58,7 @@ class GeneralSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
-          onTap: () {
+          onTap: () async {
             _onAdvancedTapped(context);
           },
         ),

--- a/lib/ui/settings/general_section_widget.dart
+++ b/lib/ui/settings/general_section_widget.dart
@@ -5,7 +5,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/advanced_settings_screen.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/payment/subscription.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/utils/dialog_util.dart';

--- a/lib/ui/settings/general_section_widget.dart
+++ b/lib/ui/settings/general_section_widget.dart
@@ -8,7 +8,6 @@ import 'package:photos/ui/components/expandable_menu_item_widget.dart';
 import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/payment/subscription.dart';
 import 'package:photos/ui/settings/common_settings.dart';
-import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/navigation_util.dart';
 
 class GeneralSectionWidget extends StatelessWidget {
@@ -46,8 +45,9 @@ class GeneralSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
           onTap: () async {
-            _onFamilyPlansTapped(context);
+            await _onFamilyPlansTapped(context);
           },
         ),
         sectionOptionSpacing,
@@ -78,11 +78,8 @@ class GeneralSectionWidget extends StatelessWidget {
   }
 
   Future<void> _onFamilyPlansTapped(BuildContext context) async {
-    final dialog = createProgressDialog(context, "Please wait...");
-    await dialog.show();
     final userDetails =
         await UserService.instance.getUserDetailsV2(memoryCount: false);
-    await dialog.hide();
     BillingService.instance.launchFamilyPortal(context, userDetails);
   }
 

--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -119,6 +119,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
         pressedColor: getEnteColorScheme(context).fillFaint,
         trailingIcon: Icons.chevron_right_outlined,
         trailingIconIsMuted: true,
+        showOnlyLoadingState: true,
         onTap: () async {
           final hasAuthenticated = await LocalAuthenticationService.instance
               .requestLocalAuthentication(

--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -11,7 +11,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/account/sessions_page.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/toggle_switch_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 

--- a/lib/ui/settings/social_section_widget.dart
+++ b/lib/ui/settings/social_section_widget.dart
@@ -3,7 +3,7 @@ import 'package:photos/services/update_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 

--- a/lib/ui/settings/social_section_widget.dart
+++ b/lib/ui/settings/social_section_widget.dart
@@ -69,7 +69,7 @@ class SocialsMenuItemWidget extends StatelessWidget {
       pressedColor: getEnteColorScheme(context).fillFaint,
       trailingIcon: Icons.chevron_right_outlined,
       trailingIconIsMuted: true,
-      onTap: () {
+      onTap: () async {
         launchUrlString(urlSring);
       },
     );

--- a/lib/ui/settings/support_section_widget.dart
+++ b/lib/ui/settings/support_section_widget.dart
@@ -7,7 +7,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/common/web_page.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/about_section_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/utils/email_util.dart';

--- a/lib/ui/settings/support_section_widget.dart
+++ b/lib/ui/settings/support_section_widget.dart
@@ -54,7 +54,7 @@ class SupportSectionWidget extends StatelessWidget {
           pressedColor: getEnteColorScheme(context).fillFaint,
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
-          onTap: () {
+          onTap: () async {
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (BuildContext context) {

--- a/lib/ui/settings/theme_switch_widget.dart
+++ b/lib/ui/settings/theme_switch_widget.dart
@@ -5,7 +5,7 @@ import 'package:photos/ente_theme_data.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 
 class ThemeSwitchWidget extends StatefulWidget {

--- a/lib/ui/sharing/add_partipant_page.dart
+++ b/lib/ui/sharing/add_partipant_page.dart
@@ -8,7 +8,7 @@ import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/ui/components/menu_section_title.dart';
 import 'package:photos/ui/components/models/button_type.dart';

--- a/lib/ui/sharing/album_participants_page.dart
+++ b/lib/ui/sharing/album_participants_page.dart
@@ -160,7 +160,7 @@ class _AlbumParticipantsPageState extends State<AlbumParticipantsPage> {
                           trailingIconIsMuted: true,
                           onTap: () async {
                             if (isOwner) {
-                              await _navigateToManageUser(currentUser);
+                              _navigateToManageUser(currentUser);
                             }
                           },
                           isTopBorderRadiusRemoved: listIndex > 0,
@@ -185,7 +185,7 @@ class _AlbumParticipantsPageState extends State<AlbumParticipantsPage> {
                       menuItemColor: getEnteColorScheme(context).fillFaint,
                       pressedColor: getEnteColorScheme(context).fillFaint,
                       onTap: () async {
-                        await _navigateToAddUser(false);
+                        _navigateToAddUser(false);
                       },
                       isTopBorderRadiusRemoved: collaborators.isNotEmpty,
                       borderRadius: 8,
@@ -259,7 +259,7 @@ class _AlbumParticipantsPageState extends State<AlbumParticipantsPage> {
                       menuItemColor: getEnteColorScheme(context).fillFaint,
                       pressedColor: getEnteColorScheme(context).fillFaint,
                       onTap: () async {
-                        await _navigateToAddUser(true);
+                        _navigateToAddUser(true);
                       },
                       isTopBorderRadiusRemoved: viewers.isNotEmpty,
                       borderRadius: 8,

--- a/lib/ui/sharing/album_participants_page.dart
+++ b/lib/ui/sharing/album_participants_page.dart
@@ -5,7 +5,7 @@ import 'package:photos/models/collection.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_title.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/ui/components/title_bar_widget.dart';

--- a/lib/ui/sharing/manage_album_participant.dart
+++ b/lib/ui/sharing/manage_album_participant.dart
@@ -80,7 +80,6 @@ class _ManageIndividualParticipantState
                         widget.collection,
                         widget.user.email,
                         role: CollectionParticipantRole.collaborator,
-                        showProgress: true,
                       );
                       if ((result ?? false) && mounted) {
                         widget.user.role = CollectionParticipantRole
@@ -113,7 +112,6 @@ class _ManageIndividualParticipantState
                         widget.collection,
                         widget.user.email,
                         role: CollectionParticipantRole.viewer,
-                        showProgress: true,
                       );
                       if ((result ?? false) && mounted) {
                         widget.user.role =
@@ -139,6 +137,7 @@ class _ManageIndividualParticipantState
               leadingIconColor: warning500,
               menuItemColor: getEnteColorScheme(context).fillFaint,
               pressedColor: getEnteColorScheme(context).fillFaint,
+              surfaceExecutionStates: false,
               onTap: () async {
                 final result = await collectionActions.removeParticipant(
                   context,

--- a/lib/ui/sharing/manage_album_participant.dart
+++ b/lib/ui/sharing/manage_album_participant.dart
@@ -4,14 +4,12 @@ import 'package:photos/services/collections_service.dart';
 import 'package:photos/theme/colors.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
-import 'package:photos/ui/components/action_sheet_widget.dart';
 import 'package:photos/ui/components/button_widget.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
 import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/ui/components/menu_section_title.dart';
-import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/utils/dialog_util.dart';
 
@@ -84,7 +82,6 @@ class _ManageIndividualParticipantState
                         widget.collection,
                         widget.user.email,
                         CollectionParticipantRole.collaborator,
-                        showProgress: true,
                       );
                       if (result && mounted) {
                         widget.user.role = CollectionParticipantRole
@@ -107,53 +104,38 @@ class _ManageIndividualParticipantState
               leadingIconColor: getEnteColorScheme(context).strokeBase,
               menuItemColor: getEnteColorScheme(context).fillFaint,
               trailingIcon: widget.user.isViewer ? Icons.check : null,
+              showOnlyLoadingState: true,
               onTap: widget.user.isViewer
                   ? null
                   : () async {
-                      final ButtonAction? result = await showActionSheet(
-                        context: context,
-                        buttons: [
-                          ButtonWidget(
-                            buttonType: ButtonType.critical,
-                            isInAlert: true,
-                            shouldStickToDarkTheme: true,
-                            buttonAction: ButtonAction.first,
-                            shouldSurfaceExecutionStates: true,
-                            labelText: "Yes, convert to viewer",
-                            onTap: () async {
-                              isConvertToViewSuccess =
-                                  await collectionActions.addEmailToCollection(
-                                context,
-                                widget.collection,
-                                widget.user.email,
-                                CollectionParticipantRole.viewer,
-                              );
-                            },
-                          ),
-                          const ButtonWidget(
-                            buttonType: ButtonType.secondary,
-                            buttonAction: ButtonAction.cancel,
-                            isInAlert: true,
-                            shouldStickToDarkTheme: true,
-                            labelText: "Cancel",
-                          )
-                        ],
+                      final ButtonAction? result = await showChoiceActionSheet(
+                        context,
                         title: "Change permissions?",
+                        firstButtonLabel: "Yes, convert to viewer",
                         body:
                             '${widget.user.email} will not be able to add more photos to this album\n\nThey will still be able to remove existing photos added by them',
+                        isCritical: true,
                       );
                       if (result != null) {
-                        if (result == ButtonAction.error) {
-                          showGenericErrorDialog(context: context);
-                        }
-                        if (result == ButtonAction.first &&
-                            isConvertToViewSuccess &&
-                            mounted) {
-                          // reset value
-                          isConvertToViewSuccess = false;
-                          widget.user.role =
-                              CollectionParticipantRole.viewer.toStringVal();
-                          setState(() => {});
+                        if (result == ButtonAction.first) {
+                          try {
+                            isConvertToViewSuccess =
+                                await collectionActions.addEmailToCollection(
+                              context,
+                              widget.collection,
+                              widget.user.email,
+                              CollectionParticipantRole.viewer,
+                            );
+                          } catch (e) {
+                            showGenericErrorDialog(context: context);
+                          }
+                          if (isConvertToViewSuccess && mounted) {
+                            // reset value
+                            isConvertToViewSuccess = false;
+                            widget.user.role =
+                                CollectionParticipantRole.viewer.toStringVal();
+                            setState(() => {});
+                          }
                         }
                       }
                     },

--- a/lib/ui/sharing/manage_album_participant.dart
+++ b/lib/ui/sharing/manage_album_participant.dart
@@ -6,7 +6,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/ui/components/menu_section_title.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';

--- a/lib/ui/sharing/manage_links_widget.dart
+++ b/lib/ui/sharing/manage_links_widget.dart
@@ -113,6 +113,7 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                     ),
                     trailingIcon: Icons.chevron_right,
                     menuItemColor: enteColorScheme.fillFaint,
+                    surfaceExecutionStates: false,
                     onTap: () async {
                       await showPicker();
                     },
@@ -140,6 +141,7 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                     onTap: () async {
                       await _showDeviceLimitPicker();
                     },
+                    surfaceExecutionStates: false,
                   ),
                   DividerWidget(
                     dividerType: DividerType.menuNoIcon,
@@ -225,6 +227,7 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                     leadingIconColor: warning500,
                     menuItemColor: getEnteColorScheme(context).fillFaint,
                     pressedColor: getEnteColorScheme(context).fillFaint,
+                    surfaceExecutionStates: false,
                     onTap: () async {
                       final bool result = await sharingActions.disableUrl(
                         context,

--- a/lib/ui/sharing/manage_links_widget.dart
+++ b/lib/ui/sharing/manage_links_widget.dart
@@ -14,7 +14,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/utils/crypto_util.dart';
 import 'package:photos/utils/date_time_util.dart';

--- a/lib/ui/sharing/share_collection_page.dart
+++ b/lib/ui/sharing/share_collection_page.dart
@@ -8,7 +8,7 @@ import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/divider_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/ui/components/menu_section_title.dart';
 import 'package:photos/ui/sharing/add_partipant_page.dart';

--- a/lib/ui/sharing/share_collection_page.dart
+++ b/lib/ui/sharing/share_collection_page.dart
@@ -170,6 +170,7 @@ class _ShareCollectionPageState extends State<ShareCollectionPage> {
               leadingIcon: Icons.copy,
               menuItemColor: getEnteColorScheme(context).fillFaint,
               pressedColor: getEnteColorScheme(context).fillFaint,
+              showOnlyLoadingState: true,
               onTap: () async {
                 await Clipboard.setData(ClipboardData(text: url));
                 showShortToast(context, "Link copied to clipboard");
@@ -239,6 +240,7 @@ class _ShareCollectionPageState extends State<ShareCollectionPage> {
           menuItemColor: getEnteColorScheme(context).fillFaint,
           pressedColor: getEnteColorScheme(context).fillFaint,
           isBottomBorderRadiusRemoved: true,
+          showOnlyLoadingState: true,
           onTap: () async {
             final bool result =
                 await collectionActions.enableUrl(context, widget.collection);
@@ -259,6 +261,7 @@ class _ShareCollectionPageState extends State<ShareCollectionPage> {
           leadingIcon: Icons.link,
           menuItemColor: getEnteColorScheme(context).fillFaint,
           pressedColor: getEnteColorScheme(context).fillFaint,
+          showOnlyLoadingState: true,
           onTap: () async {
             final bool result = await collectionActions.enableUrl(
               context,

--- a/lib/ui/tools/debug/app_storage_viewer.dart
+++ b/lib/ui/tools/debug/app_storage_viewer.dart
@@ -164,6 +164,7 @@ class _AppStorageViewerState extends State<AppStorageViewer> {
                             pressedColor:
                                 getEnteColorScheme(context).fillFaintPressed,
                             borderRadius: 8,
+                            alwaysShowSuccessState: true,
                             onTap: () async {
                               for (var pathItem in paths) {
                                 if (pathItem.allowCacheClear) {

--- a/lib/ui/tools/debug/app_storage_viewer.dart
+++ b/lib/ui/tools/debug/app_storage_viewer.dart
@@ -9,7 +9,7 @@ import 'package:photos/services/feature_flag_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/icon_button_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_title.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/ui/components/title_bar_widget.dart';

--- a/lib/ui/tools/debug/path_storage_viewer.dart
+++ b/lib/ui/tools/debug/path_storage_viewer.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/utils/data_util.dart';
 import 'package:photos/utils/directory_content.dart';
 

--- a/lib/ui/tools/debug/path_storage_viewer.dart
+++ b/lib/ui/tools/debug/path_storage_viewer.dart
@@ -76,6 +76,7 @@ class _PathStorageViewerState extends State<PathStorageViewer> {
 
   Widget _buildMenuItemWidget(DirectoryStat? stat, Object? err) {
     return MenuItemWidget(
+      key: UniqueKey(),
       alignCaptionedTextToLeft: true,
       captionedTextWidget: CaptionedTextWidget(
         title: widget.item.title,
@@ -102,6 +103,7 @@ class _PathStorageViewerState extends State<PathStorageViewer> {
       menuItemColor: getEnteColorScheme(context).fillFaint,
       isBottomBorderRadiusRemoved: widget.removeBottomRadius,
       isTopBorderRadiusRemoved: widget.removeTopRadius,
+      showOnlyLoadingState: true,
       onTap: () async {
         if (kDebugMode) {
           await Clipboard.setData(ClipboardData(text: widget.item.path));

--- a/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/lib/ui/viewer/gallery/device_folder_page.dart
@@ -15,7 +15,7 @@ import 'package:photos/services/ignored_files_service.dart';
 import 'package:photos/services/remote_sync_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
-import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import 'package:photos/ui/components/menu_section_description_widget.dart';
 import 'package:photos/ui/components/toggle_switch_widget.dart';
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';

--- a/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/lib/ui/viewer/gallery/device_folder_page.dart
@@ -238,6 +238,7 @@ class _ResetIgnoredFilesWidgetState extends State<ResetIgnoredFilesWidget> {
           borderRadius: 8.0,
           menuItemColor: getEnteColorScheme(context).fillFaint,
           leadingIcon: Icons.cloud_off_outlined,
+          alwaysShowSuccessState: true,
           onTap: () async {
             await _removeFilesFromIgnoredFiles(
               widget.filesInDeviceCollection,


### PR DESCRIPTION
## Description

- Refactored code, mainly MenuItemWidget
- Execution states can now be shown on the trailing icon of MenuItemWidget

#### On the MenuItemWidget now we can configure if : 
- To only show loading state.

https://user-images.githubusercontent.com/77285023/216050342-10c9d514-ddd1-44b6-bcde-17f163566d3e.mov

- To show success state even if the execution takes less that debounce time.

https://user-images.githubusercontent.com/77285023/216050694-b2979ad3-20fb-477b-a38b-793f3b4e406a.mp4

- To surface the execution states or not. Here's a screen recording where all execution states are surfaced when execution time > debounce time.

https://user-images.githubusercontent.com/77285023/216051848-b37412bc-af89-4acf-b67b-b4402f32c940.mp4

- Removed the use of old loading dialogs associated with MenuItemWidget.
- And some other UI improvements.
- One minor fix unrelated to this PR : To not show owner avatar of a collection on AlbumListItem on CreateCollectionSheet.

## Test Plan

Tested locally.