### PR TITLE
Fix: Skip syncAll call if user is logged out

### DIFF
--- a/lib/services/local_sync_service.dart
+++ b/lib/services/local_sync_service.dart
@@ -171,6 +171,10 @@ class LocalSyncService {
   }
 
   Future<bool> syncAll() async {
+    if (!Configuration.instance.isLoggedIn()) {
+      _logger.warning("syncCall called when user is not logged in");
+      return false;
+    }
     final stopwatch = EnteWatch("localSyncAll")..start();
 
     final localAssets = await getAllLocalAssets();


### PR DESCRIPTION
Ref: https://sentry.ente.io/organizations/ente/issues/10895/?referrer=webhooks_plugin

For logged out user, the userID won't be configured. We need userID to identify if the file with localID belongs to current user or someone else.