### PR TITLE
Fix bug in mapping existingFilesInDifferentCollection

### DIFF
--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -603,7 +603,9 @@ class FileUploader {
     // case c and d
     final File? fileExistsButDifferentCollection =
         existingUploadedFiles.firstWhereOrNull(
-      (e) => e.collectionID != toCollectionID,
+      (e) =>
+          e.collectionID != toCollectionID &&
+          (e.localID == null || e.localID == fileToUpload.localID),
     );
     if (fileExistsButDifferentCollection != null) {
       _logger.fine(


### PR DESCRIPTION
> c) A uploaded file exist with same localID but in a different collection.
    or
    d) Uploaded file in different collection but missing localID.
    For both c and d, perform add to collection operation.

**Bug:** If a file with different local ID was present in different collection, we were linking the fileToBeUploaded with the same file.