### PR TITLE
Bug fix for sharing files from outside ente when app is not in memory

### DIFF
--- a/lib/ui/home_widget.dart
+++ b/lib/ui/home_widget.dart
@@ -176,7 +176,7 @@ class _HomeWidgetState extends State<HomeWidget> {
         });
       }
     });
-    // For sharing images coming from outside the app while the app is in the memory
+    // For sharing images coming from outside the app
     _initMediaShareSubscription();
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => Future.delayed(
@@ -237,6 +237,7 @@ class _HomeWidgetState extends State<HomeWidget> {
   }
 
   void _initMediaShareSubscription() {
+    // For sharing images coming from outside the app while the app is in the memory
     _intentDataStreamSubscription =
         ReceiveSharingIntent.getMediaStream().listen(
       (List<SharedMediaFile> value) {
@@ -253,6 +254,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     ReceiveSharingIntent.getInitialMedia().then((List<SharedMediaFile> value) {
       setState(() {
         _sharedFiles = value;
+        _shouldRenderCreateCollectionSheet = true;
       });
     });
   }


### PR DESCRIPTION
## Description

The 'add to album'/'create album' sheet was not coming up when a file is shared from outside ente when the app is not in memory. This PR fixes this bug.
