### PR TITLE
Remove deprecated location search endpoint

### DIFF
--- a/lib/services/search_service.dart
+++ b/lib/services/search_service.dart
@@ -61,13 +61,10 @@ class SearchService {
     final List<GenericSearchResult> searchResults = [];
     try {
       final List<File> allFiles = await _getAllFiles();
-      final response = await _enteDio.get(
-        "/search/location",
-        queryParameters: {"query": query, "limit": 10},
-      );
-
-      final matchedLocationSearchResults =
-          LocationApiResponse.fromMap(response.data);
+      // This code used an deprecated API earlier. We've retained the
+      // scaffolding for when we implement a client side location search, and
+      // meanwhile have replaced the API response.data with an empty map here.
+      final matchedLocationSearchResults = LocationApiResponse.fromMap({});
 
       for (var locationData in matchedLocationSearchResults.results) {
         final List<File> filesInLocation = [];


### PR DESCRIPTION
This API endpoint had not been in use anyway, it was only a test endpoint that was enabled for internal debug builds. Remove it completely now, but retain the scaffolding around location search for when we implement location search.

## Test Plan

Tested a local build, and verified that searching for a location does not produce any results even for debug builds.