### PR TITLE
Bug fix text input dialog

### DIFF
--- a/lib/ui/components/text_input_widget.dart
+++ b/lib/ui/components/text_input_widget.dart
@@ -60,9 +60,7 @@ class _TextInputWidgetState extends State<TextInputWidget> {
 
   @override
   void initState() {
-    widget.submitNotifier?.addListener(() {
-      _onSubmit();
-    });
+    widget.submitNotifier?.addListener(_onSubmit);
 
     if (widget.initialValue != null) {
       _textController.value = TextEditingValue(
@@ -75,7 +73,7 @@ class _TextInputWidgetState extends State<TextInputWidget> {
 
   @override
   void dispose() {
-    widget.submitNotifier?.dispose();
+    widget.submitNotifier?.removeListener(_onSubmit);
     _textController.dispose();
     super.dispose();
   }

--- a/lib/utils/dialog_util.dart
+++ b/lib/utils/dialog_util.dart
@@ -254,7 +254,8 @@ Future<ButtonResult?> showConfettiDialog<T>({
   );
 }
 
-Future<Exception?> showTextInputDialog(
+//Can return ButtonResult? from ButtonWidget or Exception? from TextInputDialog
+Future<dynamic> showTextInputDialog(
   BuildContext context, {
   required String title,
   String? body,


### PR DESCRIPTION
## Description

The `TextInputDialog` wasn't getting dismissed. The issue was the dialog has two different widgets, `ButtonWidget` and `TextInputWidget`. The dialog returns different data types depending from which of these two `Navigator.pop()` is getting called. For example, clicking on 'Cancel' `Navigator.pop()` is called from `ButtonWidget` and `Navigator.pop()` is called from `TextInputWidget` when the the text is submitted and executed. So had to make the return type of the dialog `dynamic` to work in both of the cases.