### PR TITLE
Performance improvements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:background_fetch/background_fetch.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import "package:flutter/rendering.dart";
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photos/app.dart';
@@ -54,6 +55,7 @@ const kFGTaskDeathTimeoutInMicroseconds = 5000000;
 const kBackgroundLockLatency = Duration(seconds: 3);
 
 void main() async {
+  debugRepaintRainbowEnabled = false;
   WidgetsFlutterBinding.ensureInitialized();
   await _runInForeground();
   BackgroundFetch.registerHeadlessTask(_headlessTaskHandler);

--- a/lib/ui/viewer/gallery/collection_page.dart
+++ b/lib/ui/viewer/gallery/collection_page.dart
@@ -16,13 +16,13 @@ import 'package:photos/ui/viewer/gallery/empty_state.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
 
-class CollectionPage extends StatefulWidget {
+class CollectionPage extends StatelessWidget {
   final CollectionWithThumbnail c;
   final String tagPrefix;
   final GalleryType appBarType;
   final bool hasVerifiedLock;
 
-  const CollectionPage(
+  CollectionPage(
     this.c, {
     this.tagPrefix = "collection",
     this.appBarType = GalleryType.ownedCollection,
@@ -30,42 +30,24 @@ class CollectionPage extends StatefulWidget {
     Key? key,
   }) : super(key: key);
 
-  @override
-  State<CollectionPage> createState() => _CollectionPageState();
-}
-
-class _CollectionPageState extends State<CollectionPage> {
   final _selectedFiles = SelectedFiles();
 
   final GlobalKey shareButtonKey = GlobalKey();
-  final ValueNotifier<double> _bottomPosition = ValueNotifier(-150.0);
-
-  @override
-  void initState() {
-    _selectedFiles.addListener(_selectedFilesListener);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _selectedFiles.removeListener(_selectedFilesListener);
-    super.dispose();
-  }
 
   @override
   Widget build(Object context) {
-    if (widget.hasVerifiedLock == false && widget.c.collection.isHidden()) {
+    if (hasVerifiedLock == false && c.collection.isHidden()) {
       return const EmptyState();
     }
 
-    final appBarTypeValue = _getGalleryType(widget.c.collection);
+    final appBarTypeValue = _getGalleryType(c.collection);
     final List<File>? initialFiles =
-        widget.c.thumbnail != null ? [widget.c.thumbnail!] : null;
+        c.thumbnail != null ? [c.thumbnail!] : null;
     final gallery = Gallery(
       asyncLoader: (creationStartTime, creationEndTime, {limit, asc}) async {
         final FileLoadResult result =
             await FilesDB.instance.getFilesInCollection(
-          widget.c.collection.id,
+          c.collection.id,
           creationStartTime,
           creationEndTime,
           limit: limit,
@@ -82,25 +64,25 @@ class _CollectionPageState extends State<CollectionPage> {
       },
       reloadEvent: Bus.instance
           .on<CollectionUpdatedEvent>()
-          .where((event) => event.collectionID == widget.c.collection.id),
+          .where((event) => event.collectionID == c.collection.id),
       removalEventTypes: const {
         EventType.deletedFromRemote,
         EventType.deletedFromEverywhere,
         EventType.hide,
       },
-      tagPrefix: widget.tagPrefix,
+      tagPrefix: tagPrefix,
       selectedFiles: _selectedFiles,
       initialFiles: initialFiles,
-      albumName: widget.c.collection.name,
+      albumName: c.collection.name,
     );
     return Scaffold(
       appBar: PreferredSize(
         preferredSize: const Size.fromHeight(50.0),
         child: GalleryAppBarWidget(
           appBarTypeValue,
-          widget.c.collection.name,
+          c.collection.name,
           _selectedFiles,
-          collection: widget.c.collection,
+          collection: c.collection,
         ),
       ),
       body: Stack(
@@ -110,7 +92,7 @@ class _CollectionPageState extends State<CollectionPage> {
           FileSelectionOverlayBar(
             appBarTypeValue,
             _selectedFiles,
-            collection: widget.c.collection,
+            collection: c.collection,
           )
         ],
       ),
@@ -129,12 +111,6 @@ class _CollectionPageState extends State<CollectionPage> {
     } else if (c.type == CollectionType.favorites) {
       return GalleryType.favorite;
     }
-    return widget.appBarType;
-  }
-
-  _selectedFilesListener() {
-    _selectedFiles.files.isNotEmpty
-        ? _bottomPosition.value = 0.0
-        : _bottomPosition.value = -150.0;
+    return appBarType;
   }
 }

--- a/lib/ui/viewer/gallery/trash_page.dart
+++ b/lib/ui/viewer/gallery/trash_page.dart
@@ -14,7 +14,7 @@ import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
 import 'package:photos/utils/delete_file_util.dart';
 
-class TrashPage extends StatefulWidget {
+class TrashPage extends StatelessWidget {
   final String tagPrefix;
   final GalleryType appBarType;
   final GalleryType overlayType;
@@ -27,29 +27,8 @@ class TrashPage extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<TrashPage> createState() => _TrashPageState();
-}
-
-class _TrashPageState extends State<TrashPage> {
-  late Function() _selectedFilesListener;
-  @override
-  void initState() {
-    _selectedFilesListener = () {
-      setState(() {});
-    };
-    widget._selectedFiles.addListener(_selectedFilesListener);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    widget._selectedFiles.removeListener(_selectedFilesListener);
-    super.dispose();
-  }
-
-  @override
   Widget build(Object context) {
-    final bool filesAreSelected = widget._selectedFiles.files.isNotEmpty;
+    final bool filesAreSelected = _selectedFiles.files.isNotEmpty;
 
     final gallery = Gallery(
       asyncLoader: (creationStartTime, creationEndTime, {limit, asc}) {
@@ -70,8 +49,8 @@ class _TrashPageState extends State<TrashPage> {
       forceReloadEvents: [
         Bus.instance.on<ForceReloadTrashPageEvent>(),
       ],
-      tagPrefix: widget.tagPrefix,
-      selectedFiles: widget._selectedFiles,
+      tagPrefix: tagPrefix,
+      selectedFiles: _selectedFiles,
       header: _headerWidget(),
       initialFiles: null,
     );
@@ -80,9 +59,9 @@ class _TrashPageState extends State<TrashPage> {
       appBar: PreferredSize(
         preferredSize: const Size.fromHeight(50.0),
         child: GalleryAppBarWidget(
-          widget.appBarType,
+          appBarType,
           "Trash",
-          widget._selectedFiles,
+          _selectedFiles,
         ),
       ),
       body: Stack(
@@ -109,7 +88,7 @@ class _TrashPageState extends State<TrashPage> {
               ),
             ),
           ),
-          FileSelectionOverlayBar(GalleryType.trash, widget._selectedFiles)
+          FileSelectionOverlayBar(GalleryType.trash, _selectedFiles)
         ],
       ),
     );

--- a/lib/utils/delete_file_util.dart
+++ b/lib/utils/delete_file_util.dart
@@ -13,6 +13,7 @@ import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/files_db.dart';
 import 'package:photos/events/collection_updated_event.dart';
 import 'package:photos/events/files_updated_event.dart';
+import "package:photos/events/force_reload_trash_page_event.dart";
 import 'package:photos/events/local_photos_updated_event.dart';
 import 'package:photos/models/file.dart';
 import 'package:photos/models/selected_files.dart';
@@ -264,6 +265,9 @@ Future<bool> deleteFromTrash(BuildContext context, List<File> files) async {
             source: "deleteFromTrash",
           ),
         );
+        //the FilesUpdateEvent is not reloading trash on premanently removing
+        //files, so need to fire ForceReloadTrashPageEvent
+        Bus.instance.fire(ForceReloadTrashPageEvent());
       } catch (e, s) {
         _logger.info("failed to delete from trash", e, s);
         rethrow;


### PR DESCRIPTION
## Description

- Added `debugRepaintRainbowEnabled` in `main()` and is set to false by default. Setting it to true will help in knowing which all layers are being repainted and possibly which all widgets are being rebuilt. 
- Converted `CollectionPage` and `TrashPage` to Stateless Widgets.
- The 'TrashPage' was being rebuild every time a file is selected, which was causing performance issues when the number of trashed files were large. This has been fixed.

#### Before : 

Note : Change in color of a layer shows that it is being repainted.

https://user-images.githubusercontent.com/77285023/220554400-18db77a9-bd25-4749-8bfb-39b27df80cab.mp4

#### After : 


https://user-images.githubusercontent.com/77285023/220554434-f2f0a900-cd75-4352-b199-08a1219690ca.mp4




## Test Plan

Tested manually.
