### PR TITLE
Memories FileViewer: Add Delete and Info button

### DIFF
--- a/lib/ui/actions/file/file_actions.dart
+++ b/lib/ui/actions/file/file_actions.dart
@@ -1,9 +1,13 @@
 import "package:flutter/cupertino.dart";
+import "package:modal_bottom_sheet/modal_bottom_sheet.dart";
 import "package:photos/models/file.dart";
 import "package:photos/models/file_type.dart";
+import "package:photos/theme/colors.dart";
+import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/action_sheet_widget.dart";
 import "package:photos/ui/components/button_widget.dart";
 import "package:photos/ui/components/models/button_type.dart";
+import "package:photos/ui/viewer/file/file_info_widget.dart";
 import "package:photos/utils/delete_file_util.dart";
 import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/toast_util.dart";
@@ -118,4 +122,22 @@ Future<void> showSingleFileDeleteSheet(
       actionResult!.action == ButtonAction.error) {
     showGenericErrorDialog(context: context);
   }
+}
+
+Future<void> showInfoSheet(BuildContext context, File file) async {
+  final colorScheme = getEnteColorScheme(context);
+  return showBarModalBottomSheet(
+    topControl: const SizedBox.shrink(),
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0)),
+    backgroundColor: colorScheme.backgroundElevated,
+    barrierColor: backdropFaintDark,
+    context: context,
+    builder: (BuildContext context) {
+      return Padding(
+        padding:
+            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        child: FileInfoWidget(file),
+      );
+    },
+  );
 }

--- a/lib/ui/actions/file/file_actions.dart
+++ b/lib/ui/actions/file/file_actions.dart
@@ -1,0 +1,121 @@
+import "package:flutter/cupertino.dart";
+import "package:photos/models/file.dart";
+import "package:photos/models/file_type.dart";
+import "package:photos/ui/components/action_sheet_widget.dart";
+import "package:photos/ui/components/button_widget.dart";
+import "package:photos/ui/components/models/button_type.dart";
+import "package:photos/utils/delete_file_util.dart";
+import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/toast_util.dart";
+
+Future<void> showSingleFileDeleteSheet(
+  BuildContext context,
+  File file, {
+  Function(File)? onFileRemoved,
+}) async {
+  final List<ButtonWidget> buttons = [];
+  final String fileType = file.fileType == FileType.video ? "video" : "photo";
+  final bool isBothLocalAndRemote =
+      file.uploadedFileID != null && file.localID != null;
+  final bool isLocalOnly = file.uploadedFileID == null && file.localID != null;
+  final bool isRemoteOnly = file.uploadedFileID != null && file.localID == null;
+  const String bodyHighlight = "It will be deleted from all albums.";
+  String body = "";
+  if (isBothLocalAndRemote) {
+    body = "This $fileType is in both ente and your device.";
+  } else if (isRemoteOnly) {
+    body = "This $fileType will be deleted from ente.";
+  } else if (isLocalOnly) {
+    body = "This $fileType will be deleted from your device.";
+  } else {
+    throw AssertionError("Unexpected state");
+  }
+  // Add option to delete from ente
+  if (isBothLocalAndRemote || isRemoteOnly) {
+    buttons.add(
+      ButtonWidget(
+        labelText: isBothLocalAndRemote ? "Delete from ente" : "Yes, delete",
+        buttonType: ButtonType.neutral,
+        buttonSize: ButtonSize.large,
+        shouldStickToDarkTheme: true,
+        buttonAction: ButtonAction.first,
+        shouldSurfaceExecutionStates: true,
+        isInAlert: true,
+        onTap: () async {
+          await deleteFilesFromRemoteOnly(context, [file]);
+          showShortToast(context, "Moved to trash");
+          if (isRemoteOnly) {
+            Navigator.of(context, rootNavigator: true).pop();
+            if (onFileRemoved != null) {
+              onFileRemoved(file);
+            }
+          }
+        },
+      ),
+    );
+  }
+  // Add option to delete from local
+  if (isBothLocalAndRemote || isLocalOnly) {
+    buttons.add(
+      ButtonWidget(
+        labelText: isBothLocalAndRemote ? "Delete from device" : "Yes, delete",
+        buttonType: ButtonType.neutral,
+        buttonSize: ButtonSize.large,
+        shouldStickToDarkTheme: true,
+        buttonAction: ButtonAction.second,
+        shouldSurfaceExecutionStates: false,
+        isInAlert: true,
+        onTap: () async {
+          await deleteFilesOnDeviceOnly(context, [file]);
+          if (isLocalOnly) {
+            Navigator.of(context, rootNavigator: true).pop();
+            if (onFileRemoved != null) {
+              onFileRemoved(file);
+            }
+          }
+        },
+      ),
+    );
+  }
+  if (isBothLocalAndRemote) {
+    buttons.add(
+      ButtonWidget(
+        labelText: "Delete from both",
+        buttonType: ButtonType.neutral,
+        buttonSize: ButtonSize.large,
+        shouldStickToDarkTheme: true,
+        buttonAction: ButtonAction.third,
+        shouldSurfaceExecutionStates: true,
+        isInAlert: true,
+        onTap: () async {
+          await deleteFilesFromEverywhere(context, [file]);
+          Navigator.of(context, rootNavigator: true).pop();
+          if (onFileRemoved != null) {
+            onFileRemoved(file);
+          }
+        },
+      ),
+    );
+  }
+  buttons.add(
+    const ButtonWidget(
+      labelText: "Cancel",
+      buttonType: ButtonType.secondary,
+      buttonSize: ButtonSize.large,
+      shouldStickToDarkTheme: true,
+      buttonAction: ButtonAction.fourth,
+      isInAlert: true,
+    ),
+  );
+  final actionResult = await showActionSheet(
+    context: context,
+    buttons: buttons,
+    actionSheetType: ActionSheetType.defaultActionSheet,
+    body: body,
+    bodyHighlight: bodyHighlight,
+  );
+  if (actionResult?.action != null &&
+      actionResult!.action == ButtonAction.error) {
+    showGenericErrorDialog(context: context);
+  }
+}

--- a/lib/ui/home/memories_widget.dart
+++ b/lib/ui/home/memories_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:photos/ente_theme_data.dart';
 import 'package:photos/models/memory.dart';
 import 'package:photos/services/memories_service.dart';
-import 'package:photos/ui/extents_page_view.dart';
+import "package:photos/ui/actions/file/file_actions.dart";
 import 'package:photos/ui/viewer/file/file_widget.dart';
 import 'package:photos/ui/viewer/file/thumbnail_widget.dart';
 import 'package:photos/utils/date_time_util.dart';
@@ -381,7 +381,7 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
 
   Widget _buildSwiper() {
     _pageController = PageController(initialPage: _index);
-    return ExtentsPageView.extents(
+    return PageView.builder(
       itemBuilder: (BuildContext context, int index) {
         if (index < widget.memories.length - 1) {
           final nextFile = widget.memories[index + 1].file;
@@ -405,7 +405,6 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
       },
       itemCount: widget.memories.length,
       controller: _pageController,
-      extents: 1,
       onPageChanged: (index) async {
         await MemoriesService.instance.markMemoryAsSeen(widget.memories[index]);
         if (mounted) {

--- a/lib/ui/home/memories_widget.dart
+++ b/lib/ui/home/memories_widget.dart
@@ -1,3 +1,6 @@
+import "dart:io";
+
+import "package:flutter/cupertino.dart";
 import 'package:flutter/material.dart';
 import 'package:photos/ente_theme_data.dart';
 import 'package:photos/models/memory.dart';
@@ -315,6 +318,22 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
     );
   }
 
+  void onFileDeleted() {
+    if (widget.memories.length == 1) {
+      Navigator.pop(context);
+    } else {
+      setState(() {
+        if (_index != 0) {
+          _pageController?.jumpToPage(_index - 1);
+        }
+        widget.memories.removeAt(_index);
+        if (_index != 0) {
+          _index--;
+        }
+      });
+    }
+  }
+
   Hero _buildInfoText() {
     return Hero(
       tag: widget.title,
@@ -346,17 +365,46 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
 
   Widget _buildBottomIcons() {
     final file = widget.memories[_index].file;
-    return Container(
-      alignment: Alignment.bottomRight,
-      padding: const EdgeInsets.fromLTRB(0, 0, 26, 20),
-      child: IconButton(
-        icon: Icon(
-          Icons.adaptive.share,
-          color: Colors.white, //same for both themes
+    return SafeArea(
+      child: Container(
+        alignment: Alignment.bottomRight,
+        padding: const EdgeInsets.fromLTRB(26, 0, 26, 20),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            IconButton(
+              icon: const Icon(
+                Icons.delete_outline,
+                color: Colors.white, //same for both themes
+              ),
+              onPressed: () async {
+                await showSingleFileDeleteSheet(
+                  context,
+                  file,
+                  onFileRemoved: (file) => {onFileDeleted()},
+                );
+              },
+            ),
+            IconButton(
+              icon: Icon(
+                Platform.isAndroid ? Icons.info_outline : CupertinoIcons.info,
+                color: Colors.white, //same for both themes
+              ),
+              onPressed: () {
+                showInfoSheet(context, file);
+              },
+            ),
+            IconButton(
+              icon: Icon(
+                Icons.adaptive.share,
+                color: Colors.white, //same for both themes
+              ),
+              onPressed: () {
+                share(context, [file]);
+              },
+            ),
+          ],
         ),
-        onPressed: () {
-          share(context, [file]);
-        },
       ),
     );
   }

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -51,7 +51,7 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
   late CollectionActions collectionActions;
   late bool isCollectionOwner;
 
-  // _cachedCollectionForSharedLink is primarly used to avoid creating duplicate
+  // _cachedCollectionForSharedLink is primarily used to avoid creating duplicate
   // links if user keeps on creating Create link button after selecting
   // few files. This link is reset on any selection changed;
   Collection? _cachedCollectionForSharedLink;

--- a/lib/ui/viewer/file/fading_bottom_bar.dart
+++ b/lib/ui/viewer/file/fading_bottom_bar.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/models/file.dart';
 import 'package:photos/models/file_type.dart';
@@ -12,8 +11,8 @@ import 'package:photos/models/trash_file.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/theme/colors.dart';
 import 'package:photos/theme/ente_theme.dart';
+import "package:photos/ui/actions/file/file_actions.dart";
 import 'package:photos/ui/create_collection_sheet.dart';
-import 'package:photos/ui/viewer/file/file_info_widget.dart';
 import 'package:photos/utils/delete_file_util.dart';
 import 'package:photos/utils/magic_util.dart';
 import 'package:photos/utils/share_util.dart';
@@ -273,20 +272,6 @@ class FadingBottomBarState extends State<FadingBottomBar> {
   }
 
   Future<void> _displayInfo(File file) async {
-    final colorScheme = getEnteColorScheme(context);
-    return showBarModalBottomSheet(
-      topControl: const SizedBox.shrink(),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0)),
-      backgroundColor: colorScheme.backgroundElevated,
-      barrierColor: backdropFaintDark,
-      context: context,
-      builder: (BuildContext context) {
-        return Padding(
-          padding:
-              EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-          child: FileInfoWidget(file),
-        );
-      },
-    );
+    await showInfoSheet(context, file);
   }
 }


### PR DESCRIPTION
- Refactor: Move delete single file logic inside file_actions
- Fixed typo
- Refactor: move showInfo action in file_actions
- Switch to PageView
- Memories: Add option to show info and delete file
- Fix: Clear entries from memory cache on file deletion

Test Plan:
Tested locally for all possible cases