### PR TITLE
Theme bug on app init

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -18,10 +18,12 @@ import "package:photos/utils/intent_util.dart";
 class EnteApp extends StatefulWidget {
   final Future<void> Function(String) runBackgroundTask;
   final Future<void> Function(String) killBackgroundTask;
+  final AdaptiveThemeMode? savedThemeMode;
 
   const EnteApp(
     this.runBackgroundTask,
-    this.killBackgroundTask, {
+    this.killBackgroundTask,
+    this.savedThemeMode, {
     Key? key,
   }) : super(key: key);
 
@@ -56,7 +58,7 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
       return AdaptiveTheme(
         light: lightThemeData,
         dark: darkThemeData,
-        initial: AdaptiveThemeMode.system,
+        initial: widget.savedThemeMode ?? AdaptiveThemeMode.system,
         builder: (lightTheme, dartTheme) => MaterialApp(
           title: "ente",
           themeMode: ThemeMode.system,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -118,7 +118,7 @@ Future<void> _runInBackground(String taskId) async {
 // https://stackoverflow.com/a/73796478/546896
 @pragma('vm:entry-point')
 void _headlessTaskHandler(HeadlessTask task) {
-  print("_headlessTaskHandler");
+  debugPrint("_headlessTaskHandler");
   if (task.timeout) {
     BackgroundFetch.finish(task.taskId);
   } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import "package:adaptive_theme/adaptive_theme.dart";
 import 'package:background_fetch/background_fetch.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -57,18 +58,20 @@ const kBackgroundLockLatency = Duration(seconds: 3);
 void main() async {
   debugRepaintRainbowEnabled = false;
   WidgetsFlutterBinding.ensureInitialized();
-  await _runInForeground();
+  final savedThemeMode = await AdaptiveTheme.getThemeMode();
+  await _runInForeground(savedThemeMode);
   BackgroundFetch.registerHeadlessTask(_headlessTaskHandler);
 }
 
-Future<void> _runInForeground() async {
+Future<void> _runInForeground(AdaptiveThemeMode? savedThemeMode) async {
   return await _runWithLogs(() async {
     _logger.info("Starting app in foreground");
     await _init(false, via: 'mainMethod');
     unawaited(_scheduleFGSync('appStart in FG'));
     runApp(
       AppLock(
-        builder: (args) => const EnteApp(_runBackgroundTask, _killBGTask),
+        builder: (args) =>
+            EnteApp(_runBackgroundTask, _killBGTask, savedThemeMode),
         lockScreen: const LockScreen(),
         enabled: Configuration.instance.shouldShowLockScreen(),
         lightTheme: lightThemeData,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,9 +77,17 @@ Future<void> _runInForeground(AdaptiveThemeMode? savedThemeMode) async {
         lightTheme: lightThemeData,
         darkTheme: darkThemeData,
         backgroundLockLatency: kBackgroundLockLatency,
+        savedThemeMode: _themeMode(savedThemeMode),
       ),
     );
   });
+}
+
+ThemeMode _themeMode(AdaptiveThemeMode? savedThemeMode) {
+  if (savedThemeMode == null) return ThemeMode.system;
+  if (savedThemeMode.isLight) return ThemeMode.light;
+  if (savedThemeMode.isDark) return ThemeMode.dark;
+  return ThemeMode.system;
 }
 
 Future<void> _runBackgroundTask(String taskId, {String mode = 'normal'}) async {

--- a/lib/ui/tools/app_lock.dart
+++ b/lib/ui/tools/app_lock.dart
@@ -32,11 +32,13 @@ class AppLock extends StatefulWidget {
   final Duration backgroundLockLatency;
   final ThemeData? darkTheme;
   final ThemeData? lightTheme;
+  final ThemeMode savedThemeMode;
 
   const AppLock({
     Key? key,
     required this.builder,
     required this.lockScreen,
+    required this.savedThemeMode,
     this.enabled = true,
     this.backgroundLockLatency = const Duration(seconds: 0),
     this.darkTheme,
@@ -103,7 +105,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
     return MaterialApp(
       home: this.widget.enabled ? this._lockScreen : this.widget.builder(null),
       navigatorKey: _navigatorKey,
-      themeMode: ThemeMode.system,
+      themeMode: widget.savedThemeMode,
       theme: widget.lightTheme,
       darkTheme: widget.darkTheme,
       supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Description

When the system theme is not same as the app's theme:
- The `CollectionActionSheet`'s background color is the opposite of what is expected, that is it follows the system theme which makes the texts in it not visible. This happens when a file is shared from outside ente to ente and the `CollectionActionSheet` opens up immediately.
- Same issue with the Lock Screen.
- A flicker from system theme to the app theme can be observed on app start.

All of these have been fixed in this PR by referring https://github.com/BirjuVachhani/adaptive_theme#get-thememode-at-app-start

Before : 


https://user-images.githubusercontent.com/77285023/223660742-1e44e5b7-d730-4030-9078-c1daa2095624.mp4

After : 

https://user-images.githubusercontent.com/77285023/223661158-f3e1db99-1b0d-4a00-95dd-ddc7e69c72ca.mp4


## Test Plan

Tested on Android and iOS devices.
