### PR TITLE
Fix image editor compression

### DIFF
--- a/lib/ui/tools/editor/image_editor_page.dart
+++ b/lib/ui/tools/editor/image_editor_page.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
+import "package:flutter_image_compress/flutter_image_compress.dart";
 import 'package:image_editor/image_editor.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -320,28 +321,30 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     option.addOption(ColorOption.saturation(_saturation!));
     option.addOption(ColorOption.brightness(_brightness!));
 
-    option.outputFormat = const OutputFormat.png(88);
+    option.outputFormat = const OutputFormat.jpeg(100);
 
     final DateTime start = DateTime.now();
-    final Uint8List? result = await ImageEditor.editImage(
+    Uint8List? result = await ImageEditor.editImage(
       image: img,
       imageEditorOption: option,
     );
-    _logger.info('result.length = ${result?.length}');
-    final Duration diff = DateTime.now().difference(start);
-    _logger.info('image_editor time : $diff');
-
     if (result == null) {
       _logger.severe("null result");
       showToast(context, "Something went wrong");
       return;
     }
+    _logger.info('Size before compression = ${result.length}');
+    result = await FlutterImageCompress.compressWithList(result);
+    _logger.info('Size after compression = ${result.length}');
+    final Duration diff = DateTime.now().difference(start);
+    _logger.info('image_editor time : $diff');
+
     try {
       final fileName =
           path.basenameWithoutExtension(widget.originalFile.title!) +
               "_edited_" +
               DateTime.now().microsecondsSinceEpoch.toString() +
-              path.extension(widget.originalFile.title!);
+              ".JPEG";
       //Disabling notifications for assets changing to insert the file into
       //files db before triggering a sync.
       PhotoManager.stopChangeNotify();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,7 +71,7 @@ dependencies:
   google_nav_bar: ^5.0.5
   http: ^0.13.4
   image: ^3.0.2
-  image_editor: ^1.0.0
+  image_editor: ^1.3.0
   in_app_purchase: ^3.0.7
   intl: ^0.17.0
   like_button: ^2.0.2


### PR DESCRIPTION
## Description
- [x] Upgrade image_editor
- [x] Save output file as JPEG (instead of PNG)
- [x] Compress the generated image to workaround image_editor blowing it up

## Test Plan
- [x] Tested on simulator