### PR TITLE
Flicker bug fix

### DIFF
--- a/lib/ui/viewer/file/detail_page.dart
+++ b/lib/ui/viewer/file/detail_page.dart
@@ -117,6 +117,7 @@ class _DetailPageState extends State<DetailPage> {
         key: _appBarKey,
       ),
       extendBodyBehindAppBar: true,
+      resizeToAvoidBottomInset: false,
       body: Center(
         child: Stack(
           children: [

--- a/lib/ui/viewer/location/dynamic_location_gallery_widget.dart
+++ b/lib/ui/viewer/location/dynamic_location_gallery_widget.dart
@@ -91,27 +91,32 @@ class _DynamicLocationGalleryWidgetState
       ),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
-          return SizedBox(
-            height: _galleryHeight(
-              min(
-                (widget.memoriesCountNotifier.value ?? 0),
-                galleryFilesLimit,
-              ),
-            ),
-            child: Gallery(
-              loadingWidget: const SizedBox.shrink(),
-              disableScroll: true,
-              asyncLoader: (
-                creationStartTime,
-                creationEndTime, {
-                limit,
-                asc,
-              }) async {
-                return snapshot.data as FileLoadResult;
-              },
-              tagPrefix: widget.tagPrefix,
-              shouldCollateFilesByDay: false,
-            ),
+          return LayoutBuilder(
+            builder: (context, constrains) {
+              return SizedBox(
+                height: _galleryHeight(
+                  min(
+                    (widget.memoriesCountNotifier.value ?? 0),
+                    galleryFilesLimit,
+                  ),
+                  constrains.maxWidth,
+                ),
+                child: Gallery(
+                  loadingWidget: const SizedBox.shrink(),
+                  disableScroll: true,
+                  asyncLoader: (
+                    creationStartTime,
+                    creationEndTime, {
+                    limit,
+                    asc,
+                  }) async {
+                    return snapshot.data as FileLoadResult;
+                  },
+                  tagPrefix: widget.tagPrefix,
+                  shouldCollateFilesByDay: false,
+                ),
+              );
+            },
           );
         } else {
           return const SizedBox.shrink();
@@ -121,14 +126,13 @@ class _DynamicLocationGalleryWidgetState
     );
   }
 
-  double _galleryHeight(int fileCount) {
+  double _galleryHeight(int fileCount, double widthOfGrid) {
     final photoGridSize = LocalSettings.instance.getPhotoGridSize();
     final totalWhiteSpaceBetweenPhotos =
         galleryGridSpacing * (photoGridSize - 1);
 
     final thumbnailHeight =
-        ((MediaQuery.of(context).size.width - totalWhiteSpaceBetweenPhotos) /
-            photoGridSize);
+        ((widthOfGrid - totalWhiteSpaceBetweenPhotos) / photoGridSize);
 
     final numberOfRows = (fileCount / photoGridSize).ceil();
 


### PR DESCRIPTION
## Description

- When a photo is opened and keyboard is opened (Eg: On clicking description text field in file details), the photo was getting moved up behind the sheet. This has been fixed.
- Flickering of photos in `DynamicLocationGalleryWidget` due to rebuilds as the widget had `MediaQuery.of(context)` as a dependency. Because of this, when keyboard comes up and down, it triggers a rebuild as there is a change in the dependency (`MediaQuery.of(context).size.height` changes). Used a `LayoutBuilder` to get the width of screen instead to avoid unnecessary rebuilds.
