### PR TITLE
Fix error in calculating height for gallery in location screen

### DIFF
--- a/lib/ui/viewer/file_details/creation_time_item_widget.dart
+++ b/lib/ui/viewer/file_details/creation_time_item_widget.dart
@@ -27,7 +27,8 @@ class _CreationTimeItemState extends State<CreationTimeItem> {
       leadingIcon: Icons.calendar_today_outlined,
       title: DateFormat.yMMMEd(Localizations.localeOf(context).languageCode)
           .format(
-              DateTime.fromMicrosecondsSinceEpoch(widget.file.creationTime!)),
+        DateTime.fromMicrosecondsSinceEpoch(widget.file.creationTime!),
+      ),
       subtitleSection: Future.value([
         Text(
           getTimeIn12hrFormat(dateTime) + "  " + dateTime.timeZoneName,

--- a/lib/ui/viewer/location/location_screen.dart
+++ b/lib/ui/viewer/location/location_screen.dart
@@ -30,9 +30,11 @@ class LocationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final heightOfStatusBar = MediaQuery.of(context).viewPadding.top;
+    const heightOfAppBar = 48.0;
     return Scaffold(
       appBar: const PreferredSize(
-        preferredSize: Size(double.infinity, 48),
+        preferredSize: Size(double.infinity, heightOfAppBar),
         child: TitleBarWidget(
           isSliver: false,
           isFlexibleSpaceDisabled: true,
@@ -42,7 +44,8 @@ class LocationScreen extends StatelessWidget {
       body: Column(
         children: <Widget>[
           SizedBox(
-            height: MediaQuery.of(context).size.height - 102,
+            height: MediaQuery.of(context).size.height -
+                (heightOfAppBar + heightOfStatusBar),
             width: double.infinity,
             child: const LocationGalleryWidget(),
           ),


### PR DESCRIPTION
## Description

This was causing render overflow on devices with bigger screens and white space on smaller devices on the bottom of the location screen. This PR fixes this.