### PR TITLE
Better wording for Dutch string for memories

### DIFF
--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -417,7 +417,7 @@
   "skip": "Overslaan",
   "updatingFolderSelection": "Map selectie bijwerken...",
   "itemCount": "{count, plural, one{{count} item} other{{count} items}}",
-  "yearsAgo": "{count, plural, one{{count} jaar geleden} other{{count} jaren geleden}}",
+  "yearsAgo": "{count, plural, one{{count} jaar geleden} other{{count} jaar geleden}}",
   "backupSettings": "Back-up instellingen",
   "backupOverMobileData": "Back-up maken via mobiele data",
   "backupVideos": "Back-up video's",


### PR DESCRIPTION
Changed `{count} jaren geleden` to `{count} jaar geleden`. Though both are technically correct, `jaar geleden` is much more standard and sounds better.
