### PR TITLE
Performance imporvements to thumbnail

### DIFF
--- a/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/lib/ui/viewer/file/thumbnail_widget.dart
@@ -170,11 +170,12 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
     }
     final List<Widget> viewChildren = [
       const ThumbnailPlaceHolder(),
-      AnimatedOpacity(
-        opacity: content == null ? 0 : 1.0,
-        duration: const Duration(milliseconds: 200),
-        child: content,
-      )
+      // AnimatedOpacity(
+      //   opacity: content == null ? 0 : 1.0,
+      //   duration: const Duration(milliseconds: 200),
+      //   child: content,
+      // )
+      content ?? const SizedBox(),
     ];
     if (widget.shouldShowSyncStatus && widget.file!.uploadedFileID == null) {
       viewChildren.add(const UnSyncedIcon());

--- a/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/lib/ui/viewer/file/thumbnail_widget.dart
@@ -170,11 +170,6 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
     }
     final List<Widget> viewChildren = [
       const ThumbnailPlaceHolder(),
-      // AnimatedOpacity(
-      //   opacity: content == null ? 0 : 1.0,
-      //   duration: const Duration(milliseconds: 200),
-      //   child: content,
-      // )
       content ?? const SizedBox(),
     ];
     if (widget.shouldShowSyncStatus && widget.file!.uploadedFileID == null) {

--- a/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -60,46 +60,58 @@ class GalleryFileWidget extends StatelessWidget {
             ? _onLongPressWithSelectionLimit(context, file)
             : _onLongPressNoSelectionLimit(context, file);
       },
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(1),
-        child: Stack(
-          children: [
-            Hero(
+      child: Stack(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(1),
+            child: Hero(
               tag: tag + file.tag,
-              child: ColorFiltered(
-                colorFilter: ColorFilter.mode(
-                  Colors.black.withOpacity(
-                    isFileSelected ? 0.4 : 0,
-                  ),
-                  BlendMode.darken,
-                ),
-                child: ThumbnailWidget(
-                  file,
-                  diskLoadDeferDuration: thumbnailDiskLoadDeferDuration,
-                  serverLoadDeferDuration: thumbnailServerLoadDeferDuration,
-                  shouldShowLivePhotoOverlay: true,
-                  key: Key(tag + file.tag),
-                  thumbnailSize: photoGridSize < photoGridSizeDefault
-                      ? thumbnailLargeSize
-                      : thumbnailSmallSize,
-                  shouldShowOwnerAvatar: !isFileSelected,
-                ),
-              ),
+              child: isFileSelected
+                  ? ColorFiltered(
+                      colorFilter: ColorFilter.mode(
+                        Colors.black.withOpacity(
+                          0.4,
+                        ),
+                        BlendMode.darken,
+                      ),
+                      child: ThumbnailWidget(
+                        file,
+                        diskLoadDeferDuration: thumbnailDiskLoadDeferDuration,
+                        serverLoadDeferDuration:
+                            thumbnailServerLoadDeferDuration,
+                        shouldShowLivePhotoOverlay: true,
+                        key: Key(tag + file.tag),
+                        thumbnailSize: photoGridSize < photoGridSizeDefault
+                            ? thumbnailLargeSize
+                            : thumbnailSmallSize,
+                        shouldShowOwnerAvatar: !isFileSelected,
+                      ),
+                    )
+                  : ThumbnailWidget(
+                      file,
+                      diskLoadDeferDuration: thumbnailDiskLoadDeferDuration,
+                      serverLoadDeferDuration: thumbnailServerLoadDeferDuration,
+                      shouldShowLivePhotoOverlay: true,
+                      key: Key(tag + file.tag),
+                      thumbnailSize: photoGridSize < photoGridSizeDefault
+                          ? thumbnailLargeSize
+                          : thumbnailSmallSize,
+                      shouldShowOwnerAvatar: !isFileSelected,
+                    ),
             ),
-            Visibility(
-              visible: isFileSelected,
-              child: Positioned(
-                right: 4,
-                top: 4,
-                child: Icon(
-                  Icons.check_circle_rounded,
-                  size: 20,
-                  color: selectionColor, //same for both themes
-                ),
-              ),
-            )
-          ],
-        ),
+          ),
+          isFileSelected
+              ? Positioned(
+                  right: 4,
+                  top: 4,
+                  child: Icon(
+                    Icons.check_circle_rounded,
+                    size: 20,
+                    color: selectionColor, //same for both themes
+                  ),
+                )
+              : const SizedBox.shrink(),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Description

- Refactored `GalleryFileWidget` and `ThumbnailWidget` to reduce the work done in the raster thread. 
- This change has improved performance on the UI thread too a little.
- Since there is good improvement in 99th and 90th frame rasterizer time, there should be reduction in jank caused by the raster thread.


#### This is the comparison of before and after optimization on scrolling home gallery. 3 tests were run on each and the average is taken.

<img width="620" alt="E3D3DCC9-7AB2-4D1B-A0D7-F2050B5B5453" src="https://github.com/ente-io/photos-app/assets/77285023/619f0bc9-6a16-4680-8c40-a3f95eb4cca6">

