### PR TITLE
Perf: Avoid redundant reading and decrypting all collections

### DIFF
--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -101,7 +101,10 @@ class CollectionsService {
     // Might not have synced the collection fully
     final fetchedCollections =
         await _fetchCollections(lastCollectionUpdationTime);
-    watch.log("remote fetch");
+    watch.log("remote fetch collections ${fetchedCollections.length}");
+    if (fetchedCollections.isEmpty) {
+      return;
+    }
     final updatedCollections = <Collection>[];
     int maxUpdationTime = lastCollectionUpdationTime;
     final ownerID = _config.getUserID();

--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -92,7 +92,7 @@ class CollectionsService {
 
   // sync method fetches just sync the collections, not the individual files
   // within the collection.
-  Future<List<Collection>> sync() async {
+  Future<void> sync() async {
     _logger.info("Syncing collections");
     final EnteWatch watch = EnteWatch("syncCollection")..start();
     final lastCollectionUpdationTime =
@@ -152,7 +152,6 @@ class CollectionsService {
         ),
       );
     }
-    return collections;
   }
 
   void clearCache() {


### PR DESCRIPTION
## Description

Even when there's no change in collections, on each collection sync, we are reading all collections from DB and decrypting their name and local path values.

- CollectionSync: Remove unused return value
- Perf: Avoid redundant reading and decrypting all collections

## Test Plan
