### PR TITLE
Perf: Avoid reading entire collections while sync diff

### DIFF
--- a/lib/db/collections_db.dart
+++ b/lib/db/collections_db.dart
@@ -186,6 +186,24 @@ class CollectionsDB {
     return collections;
   }
 
+  // getActiveCollectionIDsAndUpdationTime returns map of collectionID to
+  // updationTime for non-deleted collections
+  Future<Map<int, int>> getActiveIDsAndRemoteUpdateTime() async {
+    final db = await instance.database;
+    final rows = await db.query(
+      table,
+      where: '($columnIsDeleted = ? OR $columnIsDeleted IS NULL)',
+      whereArgs: [_sqlBoolFalse],
+      columns: [columnID, columnUpdationTime],
+    );
+    final collectionIDsAndUpdationTime = <int, int>{};
+    for (final row in rows) {
+      collectionIDsAndUpdationTime[row[columnID] as int] =
+          int.parse(row[columnUpdationTime] as String);
+    }
+    return collectionIDsAndUpdationTime;
+  }
+
   Future<int> deleteCollection(int collectionID) async {
     final db = await instance.database;
     return db.delete(

--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -165,15 +165,18 @@ class CollectionsService {
     _cachedKeys.clear();
   }
 
-  Future<List<Collection>> getCollectionsToBeSynced() async {
-    final collections = await _db.getAllCollections();
-    final updatedCollections = <Collection>[];
-    for (final c in collections) {
-      if (c.updationTime > getCollectionSyncTime(c.id) && !c.isDeleted) {
-        updatedCollections.add(c);
+  Future<Map<int, int>> getCollectionIDsToBeSynced() async {
+    final idsToRemoveUpdateTimeMap =
+        await _db.getActiveIDsAndRemoteUpdateTime();
+    final result = <int, int>{};
+    for (final MapEntry<int, int> e in idsToRemoveUpdateTimeMap.entries) {
+      final int cid = e.key;
+      final int remoteUpdateTime = e.value;
+      if (remoteUpdateTime > getCollectionSyncTime(cid)) {
+        result[cid] = remoteUpdateTime;
       }
     }
-    return updatedCollections;
+    return result;
   }
 
   Set<int> getArchivedCollections() {

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -181,14 +181,19 @@ class RemoteSyncService {
   }
 
   Future<void> _syncUpdatedCollections() async {
-    final updatedCollections =
-        await _collectionsService.getCollectionsToBeSynced();
-    for (final c in updatedCollections) {
+    final idsToRemoteUpdationTimeMap =
+        await _collectionsService.getCollectionIDsToBeSynced();
+    for (final cid in idsToRemoteUpdationTimeMap.keys) {
       await _syncCollectionDiff(
-        c.id,
-        _collectionsService.getCollectionSyncTime(c.id),
+        cid,
+        _collectionsService.getCollectionSyncTime(cid),
       );
-      await _collectionsService.setCollectionSyncTime(c.id, c.updationTime);
+      // update syncTime for the collection in sharedPrefs. Note: the
+      // syncTime can change on remote but we might not get a diff for the
+      // collection if there are not changes in the file, but the collection
+      // metadata (name, archive status, sharing etc) has changed.
+      final remoteUpdateTime = idsToRemoteUpdationTimeMap[cid];
+      await _collectionsService.setCollectionSyncTime(cid, remoteUpdateTime);
     }
     _logger.info("All updated collections synced");
   }


### PR DESCRIPTION
Also:
- [CollectionDiff: Avoid redundant event for delete from remote](https://github.com/ente-io/photos-app/pull/1134/commits/6d8d4aeddf7bca8c0a875a1724270bd751139dbf)
- [Fix: Fire event with files for given collection](https://github.com/ente-io/photos-app/pull/1134/commits/4c6ba5c851a1e3ef4b90b7cbdc620a5ba5d336bf)