### PR TITLE
Map UI improvements

### DIFF
--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -140,6 +140,7 @@ class _MapScreenState extends State<MapScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = getEnteTextTheme(context);
     return Container(
       color: getEnteColorScheme(context).backgroundBase,
       child: SafeArea(
@@ -175,20 +176,41 @@ class _MapScreenState extends State<MapScreen> {
                     ),
                     child: SizedBox(
                       height: 116,
-                      child: ListView.builder(
-                        itemCount: visibleImages.length,
-                        scrollDirection: Axis.horizontal,
-                        padding: const EdgeInsets.symmetric(horizontal: 2),
-                        physics: const BouncingScrollPhysics(),
-                        itemBuilder: (context, index) {
-                          final image = visibleImages[index];
-                          return ImageTile(
-                            image: image,
-                            allImages: allImages,
-                            visibleImages: visibleImages,
-                            index: index,
-                          );
-                        },
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 200),
+                        switchInCurve: Curves.easeInOutExpo,
+                        switchOutCurve: Curves.easeInOutExpo,
+                        child: visibleImages.isNotEmpty
+                            ? ListView.builder(
+                                itemCount: visibleImages.length,
+                                scrollDirection: Axis.horizontal,
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 2),
+                                physics: const BouncingScrollPhysics(),
+                                itemBuilder: (context, index) {
+                                  final image = visibleImages[index];
+                                  return ImageTile(
+                                    image: image,
+                                    allImages: allImages,
+                                    visibleImages: visibleImages,
+                                    index: index,
+                                  );
+                                },
+                              )
+                            : Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    "No photos found here",
+                                    style: textTheme.large,
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    "Zoom out to see photos",
+                                    style: textTheme.smallFaint,
+                                  )
+                                ],
+                              ),
                       ),
                     ),
                   )

--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -8,6 +8,7 @@ import "package:latlong2/latlong.dart";
 import "package:logging/logging.dart";
 import "package:photos/models/file.dart";
 import "package:photos/theme/ente_theme.dart";
+import "package:photos/ui/common/loading_widget.dart";
 import "package:photos/ui/map/image_marker.dart";
 import 'package:photos/ui/map/image_tile.dart';
 import "package:photos/ui/map/map_view.dart";
@@ -141,8 +142,9 @@ class _MapScreenState extends State<MapScreen> {
   @override
   Widget build(BuildContext context) {
     final textTheme = getEnteTextTheme(context);
+    final colorScheme = getEnteColorScheme(context);
     return Container(
-      color: getEnteColorScheme(context).backgroundBase,
+      color: colorScheme.backgroundBase,
       child: SafeArea(
         top: false,
         child: Scaffold(
@@ -217,10 +219,9 @@ class _MapScreenState extends State<MapScreen> {
                 ],
               ),
               isLoading
-                  ? const SizedBox.expand(
-                      child: Center(
-                        child: CircularProgressIndicator(color: Colors.green),
-                      ),
+                  ? EnteLoadingWidget(
+                      size: 28,
+                      color: getEnteColorScheme(context).primary700,
                     )
                   : const SizedBox.shrink(),
             ],

--- a/lib/ui/map/map_view.dart
+++ b/lib/ui/map/map_view.dart
@@ -89,6 +89,7 @@ class _MapViewState extends State<MapView> {
             const OSMFranceTileLayer(),
             MarkerClusterLayerWidget(
               options: MarkerClusterLayerOptions(
+                anchor: AnchorPos.align(AnchorAlign.top),
                 maxClusterRadius: 100,
                 showPolygon: true,
                 size: const Size(75, 75),


### PR DESCRIPTION
## Description

- Added empty state for the listView of photos in the map's visible area.
- Used `EnteLoadingWidget` as loading icon.
- The map markers were not anchored correctly to its locations. When zooming out, the marker would be centered in its location but the marker's point would actually be further down. This has been fixed and can be seen in the video below.

https://github.com/ente-io/photos-app/assets/77285023/9b93e911-e28e-4535-b2e2-e6e0ec304aad


