### PR TITLE
Remove select all button from location screens

### DIFF
--- a/lib/ui/viewer/location/dynamic_location_gallery_widget.dart
+++ b/lib/ui/viewer/location/dynamic_location_gallery_widget.dart
@@ -114,6 +114,7 @@ class _DynamicLocationGalleryWidgetState
                   },
                   tagPrefix: widget.tagPrefix,
                   enableFileGrouping: false,
+                  showSelectAllByDefault: false,
                 ),
               );
             },

--- a/lib/ui/viewer/location/pick_center_point_widget.dart
+++ b/lib/ui/viewer/location/pick_center_point_widget.dart
@@ -120,6 +120,7 @@ class PickCenterPointWidget extends StatelessWidget {
                             tagPrefix: "pick_center_point_gallery",
                             selectedFiles: selectedFiles,
                             limitSelectionToOne: true,
+                            showSelectAllByDefault: false,
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Description

In add/edit location and pick center point screen, selection is not possible. So shouldn't be showing the select all button by default.
