### PR TITLE
Add collection cover/thumbnail cache

### DIFF
--- a/lib/ui/tabs/shared/incoming_album_item.dart
+++ b/lib/ui/tabs/shared/incoming_album_item.dart
@@ -14,6 +14,7 @@ import "package:photos/utils/navigation_util.dart";
 
 class IncomingAlbumItem extends StatelessWidget {
   final CollectionWithThumbnail c;
+  const String heroTagPrefix = "shared_collection";
 
   const IncomingAlbumItem(
     this.c, {
@@ -22,7 +23,6 @@ class IncomingAlbumItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final heroTag = "shared_collection" + (c.thumbnail?.tag ?? '');
     const double horizontalPaddingOfGridRow = 16;
     const double crossAxisSpacingOfGrid = 9;
     final TextStyle albumTitleTextStyle =
@@ -48,6 +48,7 @@ class IncomingAlbumItem extends StatelessWidget {
                     future: CollectionsService.instance.getCover(c.collection),
                     builder: (context, snapshot) {
                       if (snapshot.hasData) {
+                        final heroTag = heroTagPrefix + snapshot.data!.tag;
                         return Hero(
                           tag: heroTag,
                           child: ThumbnailWidget(
@@ -118,7 +119,7 @@ class IncomingAlbumItem extends StatelessWidget {
           CollectionPage(
             c,
             appBarType: GalleryType.sharedCollection,
-            tagPrefix: "shared_collection",
+            tagPrefix: heroTagPrefix,
           ),
         );
       },

--- a/lib/ui/tabs/shared/incoming_album_item.dart
+++ b/lib/ui/tabs/shared/incoming_album_item.dart
@@ -3,7 +3,9 @@ import "dart:math";
 import "package:flutter/material.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/models/collection_items.dart";
+import "package:photos/models/file.dart";
 import "package:photos/models/gallery_type.dart";
+import "package:photos/services/collections_service.dart";
 import "package:photos/ui/sharing/user_avator_widget.dart";
 import "package:photos/ui/viewer/file/no_thumbnail_widget.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
@@ -42,18 +44,25 @@ class IncomingAlbumItem extends StatelessWidget {
               width: sideOfThumbnail,
               child: Stack(
                 children: [
-                  c.thumbnail != null
-                      ? Hero(
+                  FutureBuilder<File?>(
+                    future: CollectionsService.instance.getCover(c.collection),
+                    builder: (context, snapshot) {
+                      if (snapshot.hasData) {
+                        return Hero(
                           tag: heroTag,
                           child: ThumbnailWidget(
-                            c.thumbnail,
+                            snapshot.data!,
                             key: Key(heroTag),
                             shouldShowArchiveStatus:
                                 c.collection.hasShareeArchived(),
                             shouldShowSyncStatus: false,
                           ),
-                        )
-                      : const NoThumbnailWidget(),
+                        );
+                      } else {
+                        return const NoThumbnailWidget();
+                      }
+                    },
+                  ),
                   Align(
                     alignment: Alignment.bottomRight,
                     child: Padding(

--- a/lib/ui/tabs/shared/outgoing_album_item.dart
+++ b/lib/ui/tabs/shared/outgoing_album_item.dart
@@ -12,6 +12,7 @@ import "package:photos/utils/navigation_util.dart";
 
 class OutgoingAlbumItem extends StatelessWidget {
   final CollectionWithThumbnail c;
+  static const heroTagPrefix = "outgoing_collection";
 
   const OutgoingAlbumItem({super.key, required this.c});
 
@@ -42,7 +43,7 @@ class OutgoingAlbumItem extends StatelessWidget {
         }
       }
     }
-    final String heroTag = "outgoing_collection" + (c.thumbnail?.tag ?? '');
+
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       child: Container(
@@ -58,6 +59,7 @@ class OutgoingAlbumItem extends StatelessWidget {
                   future: CollectionsService.instance.getCover(c.collection),
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
+                      final String heroTag = heroTagPrefix + snapshot.data!.tag;
                       return Hero(
                         tag: heroTag,
                         child: ThumbnailWidget(
@@ -120,7 +122,7 @@ class OutgoingAlbumItem extends StatelessWidget {
         final page = CollectionPage(
           c,
           appBarType: GalleryType.ownedCollection,
-          tagPrefix: "outgoing_collection",
+          tagPrefix: heroTagPrefix,
         );
         routeToPage(context, page);
       },

--- a/lib/ui/tabs/shared/outgoing_album_item.dart
+++ b/lib/ui/tabs/shared/outgoing_album_item.dart
@@ -1,7 +1,9 @@
 import "package:flutter/material.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/collection_items.dart";
+import "package:photos/models/file.dart";
 import "package:photos/models/gallery_type.dart";
+import "package:photos/services/collections_service.dart";
 import 'package:photos/theme/colors.dart';
 import "package:photos/ui/viewer/file/no_thumbnail_widget.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
@@ -52,15 +54,22 @@ class OutgoingAlbumItem extends StatelessWidget {
               child: SizedBox(
                 height: 60,
                 width: 60,
-                child: c.thumbnail != null
-                    ? Hero(
+                child: FutureBuilder<File?>(
+                  future: CollectionsService.instance.getCover(c.collection),
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                      return Hero(
                         tag: heroTag,
                         child: ThumbnailWidget(
-                          c.thumbnail,
+                          snapshot.data!,
                           key: ValueKey(heroTag),
                         ),
-                      )
-                    : const NoThumbnailWidget(),
+                      );
+                    } else {
+                      return const NoThumbnailWidget();
+                    }
+                  },
+                ),
               ),
             ),
             const Padding(padding: EdgeInsets.all(8)),


### PR DESCRIPTION
**Description**
In this diff, just introducing the thumbnailFile reference cache logic. Verified that this works for the shared sections.

In the upcoming diffs, will gradually start reducing the dependencies from CollectionWith thumbnail.

**Test Plan**
* Verified that the thumbnail was getting updated when we were changing the sort order.


