### PR TITLE
Remove dependency from getCollectionsWithThumbnails during collectionDelete

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -1255,6 +1255,28 @@ class FilesDB {
     return result;
   }
 
+  // getCollectionLatestFileTime returns map of collectionID to the max
+  // creationTime of the files in the collection.
+  Future<Map<int, int>> getCollectionIDToMaxCreationTime() async {
+    final db = await instance.database;
+    final rows = await db.rawQuery(
+      '''
+      SELECT $columnCollectionID, MAX($columnCreationTime) AS max_creation_time
+      FROM $filesTable
+      WHERE 
+      ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1
+       AND $columnUploadedFileID IS NOT NULL AND $columnUploadedFileID IS 
+       NOT -1)
+      GROUP BY $columnCollectionID;
+    ''',
+    );
+    final result = <int, int>{};
+    for (final row in rows) {
+      result[row[columnCollectionID] as int] = row['max_creation_time'] as int;
+    }
+    return result;
+  }
+
   // getCollectionFileFirstOrLast returns the first or last uploaded file in
   // the collection based on the given collectionID and the order.
   Future<File?> getCollectionFileFirstOrLast(

--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -1,4 +1,3 @@
-import 'dart:developer' as dev;
 import 'dart:io' as io;
 
 import 'package:flutter/foundation.dart';
@@ -511,7 +510,7 @@ class FilesDB {
     Set<int>? ignoredCollectionIDs,
     bool applyOwnerCheck = false,
   }) async {
-    final stopWatch = Stopwatch()..start();
+    final stopWatch = EnteWatch('getAllPendingOrUploadedFiles')..start();
     late String whereQuery;
     late List<Object?>? whereArgs;
     if (applyOwnerCheck) {
@@ -537,11 +536,13 @@ class FilesDB {
           '$columnCreationTime ' + order + ', $columnModificationTime ' + order,
       limit: limit,
     );
+    stopWatch.log('queryDone');
     final files = convertToFiles(results);
+    stopWatch.log('convertDone');
     final List<File> deduplicatedFiles =
         _deduplicatedAndFilterIgnoredFiles(files, ignoredCollectionIDs);
-    dev.log(
-      "getAllPendingOrUploadedFiles time taken: ${stopWatch.elapsedMilliseconds} ms",
+    stopWatch.log(
+      "dedupeDone: for ${files.length} files.",
     );
     stopWatch.stop();
     return FileLoadResult(deduplicatedFiles, files.length == limit);

--- a/lib/extensions/stop_watch.dart
+++ b/lib/extensions/stop_watch.dart
@@ -2,15 +2,25 @@ import 'package:flutter/foundation.dart';
 
 class EnteWatch extends Stopwatch {
   final String context;
+  int previousElapsed = 0;
 
   EnteWatch(this.context) : super();
 
   void log(String msg) {
-    debugPrint("[$context]: $msg took ${elapsed.inMilliseconds} ms");
+    if (kDebugMode) {
+      debugPrint("[$context]: $msg took ${Duration(
+        microseconds: elapsedMicroseconds - previousElapsed,
+      ).inMilliseconds} ms  total: "
+          "${elapsed.inMilliseconds} ms");
+    }
+    previousElapsed = elapsedMicroseconds;
   }
 
   void logAndReset(String msg) {
-    debugPrint("[$context]: $msg took ${elapsed.inMilliseconds} ms");
+    if (kDebugMode) {
+      debugPrint("[$context]: $msg took ${elapsed.inMilliseconds} ms");
+    }
     reset();
+    previousElapsed = 0;
   }
 }

--- a/lib/models/collection.dart
+++ b/lib/models/collection.dart
@@ -130,6 +130,25 @@ class Collection {
     return (owner?.id ?? 0) == userID;
   }
 
+  CollectionParticipantRole getRole(int userID) {
+    if (isOwner(userID)) {
+      return CollectionParticipantRole.owner;
+    }
+    if (sharees == null) {
+      return CollectionParticipantRole.unknown;
+    }
+    for (final User? u in sharees!) {
+      if (u != null && u.id == userID) {
+        if (u.isViewer) {
+          return CollectionParticipantRole.viewer;
+        } else if (u.isCollaborator) {
+          return CollectionParticipantRole.collaborator;
+        }
+      }
+    }
+    return CollectionParticipantRole.unknown;
+  }
+
   // canLinkToDevicePath returns true if the collection can be linked to local
   // device album based on path. The path is nothing but the name of the device
   // album.

--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -264,6 +264,33 @@ class CollectionsService {
         .toList();
   }
 
+  // returns collections after removing deleted,uncategorized, and hidden
+  // collections
+  List<Collection> getCollectionsForUI({
+    bool includedShared = false,
+    bool includeCollab = false,
+  }) {
+    final Set<CollectionParticipantRole> allowedRoles = {
+      CollectionParticipantRole.owner,
+    };
+    if (includedShared) {
+      allowedRoles.add(CollectionParticipantRole.viewer);
+    }
+    if (includedShared || includeCollab) {
+      allowedRoles.add(CollectionParticipantRole.collaborator);
+    }
+    final int userID = _config.getUserID()!;
+    return _collectionIDToCollections.values
+        .where(
+          (c) =>
+              !c.isDeleted ||
+              c.type != CollectionType.uncategorized ||
+              !c.isHidden() ||
+              allowedRoles.contains(c.getRole(userID)),
+        )
+        .toList();
+  }
+
   User getFileOwner(int userID, int? collectionID) {
     if (_cachedUserIdToUser.containsKey(userID)) {
       return _cachedUserIdToUser[userID]!;

--- a/lib/ui/tabs/shared/incoming_album_item.dart
+++ b/lib/ui/tabs/shared/incoming_album_item.dart
@@ -14,7 +14,7 @@ import "package:photos/utils/navigation_util.dart";
 
 class IncomingAlbumItem extends StatelessWidget {
   final CollectionWithThumbnail c;
-  const String heroTagPrefix = "shared_collection";
+  static const String heroTagPrefix = "shared_collection";
 
   const IncomingAlbumItem(
     this.c, {

--- a/lib/ui/viewer/actions/delete_empty_albums.dart
+++ b/lib/ui/viewer/actions/delete_empty_albums.dart
@@ -107,7 +107,7 @@ class _DeleteEmptyAlbumsState extends State<DeleteEmptyAlbums> {
             S.of(context).deleteProgress(currentlyDeleting, collections.length);
         try {
           await CollectionsService.instance.trashEmptyCollection(
-            collections[i].collection,
+            collections[i],
             isBulkDelete: true,
           );
         } catch (_) {

--- a/lib/ui/viewer/actions/delete_empty_albums.dart
+++ b/lib/ui/viewer/actions/delete_empty_albums.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:photos/core/event_bus.dart';
+import "package:photos/db/files_db.dart";
 import 'package:photos/events/collection_updated_event.dart';
 import "package:photos/generated/l10n.dart";
 import 'package:photos/models/collection.dart';
@@ -88,12 +89,13 @@ class _DeleteEmptyAlbumsState extends State<DeleteEmptyAlbums> {
   }
 
   Future<void> _deleteEmptyAlbums() async {
-    final collections =
-        await CollectionsService.instance.getCollectionsWithThumbnails();
+    final collections = CollectionsService.instance.getCollectionsForUI();
+    final idToFileTimeStamp =
+        await FilesDB.instance.getCollectionIDToMaxCreationTime();
+
     // remove collections which are not empty or can't be deleted
     collections.removeWhere(
-      (element) =>
-          element.thumbnail != null || !element.collection.type.canDelete,
+      (c) => !c.type.canDelete || idToFileTimeStamp.containsKey(c.id),
     );
     int failedCount = 0;
     for (int i = 0; i < collections.length; i++) {

--- a/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/event_bus.dart';
+import "package:photos/db/files_db.dart";
 import 'package:photos/events/subscription_purchased_event.dart';
 import "package:photos/generated/l10n.dart";
 import 'package:photos/models/backup_status.dart';
@@ -466,14 +466,9 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
   }
 
   Future<void> _trashCollection() async {
-    final collectionWithThumbnail =
-        await CollectionsService.instance.getCollectionsWithThumbnails();
-    final bool isEmptyCollection = collectionWithThumbnail
-            .firstWhereOrNull(
-              (element) => element.collection.id == widget.collection!.id,
-            )
-            ?.thumbnail ==
-        null;
+    final int count =
+        await FilesDB.instance.collectionFileCount(widget.collection!.id);
+    final bool isEmptyCollection = count == 0;
     if (isEmptyCollection) {
       final dialog = createProgressDialog(
         context,


### PR DESCRIPTION
- use collectionFileCount for identifying emptyCollection
- StopWatch: Log times during debug mode only
- Fix lint
- Log time metrics for home_page_query
- Refactor delete emptyAlbums logic
