### PR TITLE
Limit the count of items in the PlaceHolderWidget

### DIFF
--- a/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
@@ -1,3 +1,5 @@
+import "dart:math";
+
 import 'package:flutter/material.dart';
 import 'package:photos/theme/ente_theme.dart';
 
@@ -14,7 +16,8 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final key = _getCacheKey(count, columns);
+    final int limitCount = min(count, columns);
+    final key = '$limitCount:$columns';
     if (!_gridViewCache.containsKey(key)) {
       _gridViewCache[key] = GridView.builder(
         padding: const EdgeInsets.only(top: 2),
@@ -25,7 +28,7 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
             color: getEnteColorScheme(context).fillFaint,
           );
         },
-        itemCount: count,
+        itemCount: limitCount,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: columns,
           crossAxisSpacing: 2,
@@ -34,9 +37,5 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
       );
     }
     return _gridViewCache[key]!;
-  }
-
-  String _getCacheKey(int totalCount, int columns) {
-    return totalCount.toString() + ":" + columns.toString();
   }
 }

--- a/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
@@ -1,7 +1,6 @@
 import "dart:math";
 
 import 'package:flutter/material.dart';
-import 'package:photos/theme/ente_theme.dart';
 
 class PlaceHolderGridViewWidget extends StatelessWidget {
   const PlaceHolderGridViewWidget(
@@ -13,10 +12,12 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
   final int count, columns;
 
   static final _gridViewCache = <String, GridView>{};
+  static const crossAxisSpacing = 2.0; // as per your code
+  static const mainAxisSpacing = 2.0; // as per your code
 
   @override
   Widget build(BuildContext context) {
-    final int limitCount = min(count, columns);
+    final int limitCount = min(count, columns * 5);
     final key = '$limitCount:$columns';
     if (!_gridViewCache.containsKey(key)) {
       _gridViewCache[key] = GridView.builder(
@@ -24,9 +25,7 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         itemBuilder: (context, index) {
-          return Container(
-            color: getEnteColorScheme(context).fillFaint,
-          );
+          return Container(color: Colors.transparent);
         },
         itemCount: limitCount,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(


### PR DESCRIPTION
## Description
This limits the number of place holders which we are rendering on the screen.
For large number for collections, current implementation without limit is causing performance issues.

Usability and interaction wise I didn't notice any major glitch.
## Test Plan
