### PR TITLE
Gallery perf improvements

### DIFF
--- a/lib/ui/huge_listview/draggable_scrollbar.dart
+++ b/lib/ui/huge_listview/draggable_scrollbar.dart
@@ -63,6 +63,7 @@ class DraggableScrollbarState extends State<DraggableScrollbar>
     super.initState();
     currentFirstIndex = widget.currentFirstIndex;
 
+    ///Where will this be true on init?
     if (widget.initialScrollIndex > 0 && widget.totalCount > 1) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         setState(
@@ -112,18 +113,6 @@ class DraggableScrollbarState extends State<DraggableScrollbar>
       );
     } else {
       return widget.child;
-    }
-  }
-
-  Widget buildKeyboard() {
-    if (defaultTargetPlatform == TargetPlatform.windows) {
-      return RawKeyboardListener(
-        focusNode: FocusNode(),
-        onKey: keyHandler,
-        child: buildThumb(),
-      );
-    } else {
-      return buildThumb();
     }
   }
 

--- a/lib/ui/huge_listview/huge_listview.dart
+++ b/lib/ui/huge_listview/huge_listview.dart
@@ -176,7 +176,9 @@ class HugeListViewState<T> extends State<HugeListView<T>> {
               initialScrollIndex: widget.startIndex,
               itemCount: max(widget.totalCount, 0),
               itemBuilder: (context, index) {
-                return widget.itemBuilder(context, index);
+                return ExcludeSemantics(
+                  child: widget.itemBuilder(context, index),
+                );
               },
             ),
           )

--- a/lib/ui/huge_listview/huge_listview.dart
+++ b/lib/ui/huge_listview/huge_listview.dart
@@ -185,7 +185,9 @@ class HugeListViewState<T> extends State<HugeListView<T>> {
         : ListView.builder(
             itemCount: max(widget.totalCount, 0),
             itemBuilder: (context, index) {
-              return widget.itemBuilder(context, index);
+              return ExcludeSemantics(
+                child: widget.itemBuilder(context, index),
+              );
             },
           );
   }

--- a/lib/ui/viewer/gallery/component/grid/gallery_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/gallery_grid_view_widget.dart
@@ -31,15 +31,17 @@ class GalleryGridViewWidget extends StatelessWidget {
       physics: const NeverScrollableScrollPhysics(),
       // to disable GridView's scrolling
       itemBuilder: (context, index) {
-        return GalleryFileWidget(
-          file: filesInGroup[index],
-          selectedFiles: selectedFiles,
-          limitSelectionToOne: limitSelectionToOne,
-          tag: tag,
-          photoGridSize: photoGridSize,
-          currentUserID: currentUserID,
-          filesInGroup: filesInGroup,
-          asyncLoader: asyncLoader,
+        return ExcludeSemantics(
+          child: GalleryFileWidget(
+            file: filesInGroup[index],
+            selectedFiles: selectedFiles,
+            limitSelectionToOne: limitSelectionToOne,
+            tag: tag,
+            photoGridSize: photoGridSize,
+            currentUserID: currentUserID,
+            filesInGroup: filesInGroup,
+            asyncLoader: asyncLoader,
+          ),
         );
       },
       itemCount: filesInGroup.length,

--- a/lib/ui/viewer/gallery/component/grid/gallery_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/gallery_grid_view_widget.dart
@@ -31,17 +31,15 @@ class GalleryGridViewWidget extends StatelessWidget {
       physics: const NeverScrollableScrollPhysics(),
       // to disable GridView's scrolling
       itemBuilder: (context, index) {
-        return ExcludeSemantics(
-          child: GalleryFileWidget(
-            file: filesInGroup[index],
-            selectedFiles: selectedFiles,
-            limitSelectionToOne: limitSelectionToOne,
-            tag: tag,
-            photoGridSize: photoGridSize,
-            currentUserID: currentUserID,
-            filesInGroup: filesInGroup,
-            asyncLoader: asyncLoader,
-          ),
+        return GalleryFileWidget(
+          file: filesInGroup[index],
+          selectedFiles: selectedFiles,
+          limitSelectionToOne: limitSelectionToOne,
+          tag: tag,
+          photoGridSize: photoGridSize,
+          currentUserID: currentUserID,
+          filesInGroup: filesInGroup,
+          asyncLoader: asyncLoader,
         );
       },
       itemCount: filesInGroup.length,

--- a/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
@@ -32,7 +32,7 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         itemBuilder: (context, index) {
-          return Container(color: faintColor);
+          return ExcludeSemantics(child: Container(color: faintColor));
         },
         itemCount: limitCount,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(

--- a/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
@@ -32,7 +32,7 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         itemBuilder: (context, index) {
-          return ExcludeSemantics(child: Container(color: faintColor));
+          return Container(color: faintColor);
         },
         itemCount: limitCount,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(

--- a/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
+++ b/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
@@ -50,7 +50,7 @@ class LazyGroupGallery extends StatefulWidget {
 }
 
 class _LazyGroupGalleryState extends State<LazyGroupGallery> {
-  static const kNumberOfDaysToRenderBeforeAndAfter = 8;
+  static const numberOfGroupsToRenderBeforeAndAfter = 8;
 
   late Logger _logger;
 
@@ -80,7 +80,7 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
     _currentIndexSubscription =
         widget.currentIndexStream.listen((currentIndex) {
       final bool shouldRender = (currentIndex - widget.index).abs() <
-          kNumberOfDaysToRenderBeforeAndAfter;
+          numberOfGroupsToRenderBeforeAndAfter;
       if (mounted && shouldRender != _shouldRender) {
         setState(() {
           _shouldRender = shouldRender;

--- a/lib/ui/viewer/gallery/component/multiple_groups_gallery_view.dart
+++ b/lib/ui/viewer/gallery/component/multiple_groups_gallery_view.dart
@@ -22,7 +22,6 @@ If a group has more than 400 files, LazyGroupGallery internally divides the
 group into multiple grid views during rendering.
  */
 class MultipleGroupsGalleryView extends StatelessWidget {
-  final GlobalKey<HugeListViewState<dynamic>> hugeListViewKey;
   final ItemScrollController itemScroller;
   final List<List<File>> groupedFiles;
   final bool disableScroll;
@@ -43,7 +42,6 @@ class MultipleGroupsGalleryView extends StatelessWidget {
   final bool isScrollablePositionedList;
 
   const MultipleGroupsGalleryView({
-    required this.hugeListViewKey,
     required this.itemScroller,
     required this.groupedFiles,
     required this.disableScroll,
@@ -68,7 +66,6 @@ class MultipleGroupsGalleryView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return HugeListView<List<File>>(
-      key: hugeListViewKey,
       controller: itemScroller,
       startIndex: 0,
       totalCount: groupedFiles.length,

--- a/lib/ui/viewer/gallery/gallery.dart
+++ b/lib/ui/viewer/gallery/gallery.dart
@@ -12,7 +12,6 @@ import 'package:photos/models/file.dart';
 import 'package:photos/models/file_load_result.dart';
 import 'package:photos/models/selected_files.dart';
 import 'package:photos/ui/common/loading_widget.dart';
-import 'package:photos/ui/huge_listview/huge_listview.dart';
 import "package:photos/ui/viewer/gallery/component/multiple_groups_gallery_view.dart";
 import 'package:photos/ui/viewer/gallery/empty_state.dart';
 import "package:photos/ui/viewer/gallery/state/gallery_sort_order.dart";
@@ -82,8 +81,6 @@ class Gallery extends StatefulWidget {
 
 class _GalleryState extends State<Gallery> {
   static const int kInitialLoadLimit = 100;
-
-  final _hugeListViewKey = GlobalKey<HugeListViewState>();
 
   late Logger _logger;
   List<List<File>> _currentGroupedFiles = [];
@@ -226,7 +223,6 @@ class _GalleryState extends State<Gallery> {
     return GallerySortOrder(
       sortOrderAsc: _sortOrderAsc,
       child: MultipleGroupsGalleryView(
-        hugeListViewKey: _hugeListViewKey,
         itemScroller: _itemScroller,
         groupedFiles: _currentGroupedFiles,
         disableScroll: widget.disableScroll,

--- a/test_driver/perf_driver.dart
+++ b/test_driver/perf_driver.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_driver/flutter_driver.dart' as driver;
 import 'package:integration_test/integration_test_driver.dart';
 
+///https://api.flutter.dev/flutter/flutter_driver/TimelineSummary/summaryJson.html
+
 Future<void> main() {
   return integrationDriver(
     responseDataCallback: (data) async {


### PR DESCRIPTION
## Description

### Performance improvements and some minor changes. 

- The only reason why rasterizer times have increased should be because more frames are being scheduled because of improved performance in the UI thread (better frame build times) and hence more frames are to be rasterized at a given time. 
- `frame_count` and `frame_rasterizer_count` have increased and couldn't find much documentation about these but from what I understood with whatever little I read about these, this is implying increase in FPS.

<img width="330" alt="E42E07E9-C281-4321-9A6A-4F71FE6A2478" src="https://github.com/ente-io/photos-app/assets/77285023/5c231d05-3130-4cba-b079-e440680ab9b7">

