### PR TITLE
Gallery perf: Remove unneccesary reloads of subGroup on updates in it…

### DIFF
--- a/lib/ui/viewer/gallery/component/group/group_gallery.dart
+++ b/lib/ui/viewer/gallery/component/group/group_gallery.dart
@@ -38,6 +38,7 @@ class GroupGallery extends StatelessWidget {
     for (int index = 0; index < files.length; index += subGalleryItemLimit) {
       childGalleries.add(
         LazyGridView(
+          key: ValueKey("subGallery index:$index"),
           tag,
           files.sublist(
             index,


### PR DESCRIPTION
## Description

Updates to a group (in the case of gallery, photos in a day) was making subGroups flicker other than the 1st subGroup. Using keys for each subGroup resolved this issue.

- Before


https://github.com/ente-io/photos-app/assets/77285023/dd4e07f5-d7f7-42cc-a926-9e7ce33c2676

- After


https://github.com/ente-io/photos-app/assets/77285023/e5f02f2c-59a4-47d4-a64a-9d570db50d97
