### PR TITLE
Cache one placeholder to be used for all children of grid

### DIFF
--- a/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
+++ b/lib/ui/viewer/gallery/component/grid/place_holder_grid_view_widget.dart
@@ -13,6 +13,7 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
 
   final int count, columns;
 
+  static Widget? _placeHolderCache;
   static final _gridViewCache = <String, GridView>{};
   static const crossAxisSpacing = 2.0; // as per your code
   static const mainAxisSpacing = 2.0; // as per your code
@@ -32,7 +33,8 @@ class PlaceHolderGridViewWidget extends StatelessWidget {
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         itemBuilder: (context, index) {
-          return Container(color: faintColor);
+          return PlaceHolderGridViewWidget._placeHolderCache ??=
+              Container(color: faintColor);
         },
         itemCount: limitCount,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(


### PR DESCRIPTION
### Description 

`frame_count` and `frame_rasterizer_count` has increased, which means more frames, better FPS.

<img width="330" alt="Screenshot 2023-07-17 at 3 39 16 PM" src="https://github.com/ente-io/photos-app/assets/77285023/5c39c170-44d5-4e47-a618-d428c4f8d2af">
