### PR TITLE
Redesign selection sheet

### DIFF
--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -97,103 +97,101 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} Objekt', other: '${count} Objekte')}";
 
-  static String m26(count) => "${count} ausgewählt";
+  static String m26(expiryTime) => "Link läuft am ${expiryTime} ab";
 
-  static String m27(expiryTime) => "Link läuft am ${expiryTime} ab";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "Wenn auf den Höchstwert von ${maxValue} gesetzt, dann wird das Limit gelockert um potenzielle Höchstlasten unterstützen zu können.";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, zero: 'keine Erinnerungsstücke', one: '${formattedCount} Erinnerung', other: '${formattedCount} Erinnerungsstücke')}";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: 'Element verschieben', other: 'Elemente verschieben')}";
 
-  static String m31(albumName) => "Erfolgreich zu ${albumName} hinzugefügt";
+  static String m30(albumName) => "Erfolgreich zu ${albumName} hinzugefügt";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Passwortstärke: ${passwordStrengthValue}";
 
-  static String m33(providerName) =>
+  static String m32(providerName) =>
       "Bitte kontaktiere den Support von ${providerName}, falls etwas abgebucht wurde";
 
-  static String m34(reason) =>
+  static String m33(reason) =>
       "Leider ist deine Zahlung aus folgendem Grund fehlgeschlagen: ${reason}";
 
-  static String m35(toEmail) => "Bitte sende uns eine E-Mail an ${toEmail}";
+  static String m34(toEmail) => "Bitte sende uns eine E-Mail an ${toEmail}";
 
-  static String m36(toEmail) => "Bitte sende die Protokolle an ${toEmail}";
+  static String m35(toEmail) => "Bitte sende die Protokolle an ${toEmail}";
 
-  static String m37(storeName) => "Bewerte uns auf ${storeName}";
+  static String m36(storeName) => "Bewerte uns auf ${storeName}";
 
-  static String m38(storageInGB) =>
+  static String m37(storageInGB) =>
       "3. Ihr beide erhaltet ${storageInGB} GB* kostenlos";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} wird aus diesem geteilten Album entfernt\n\nAlle von ihnen hinzugefügte Fotos werden ebenfalls aus dem Album entfernt";
 
-  static String m40(endDate) => "Erneuert am ${endDate}";
+  static String m39(endDate) => "Erneuert am ${endDate}";
 
-  static String m41(count) => "${count} ausgewählt";
+  static String m40(count) => "${count} ausgewählt";
 
-  static String m42(count, yourCount) =>
+  static String m41(count, yourCount) =>
       "${count} ausgewählt (${yourCount} von Ihnen)";
 
-  static String m43(verificationID) =>
+  static String m42(verificationID) =>
       "Hier ist meine Verifizierungs-ID: ${verificationID} für ente.io.";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "Hey, kannst du bestätigen, dass dies deine ente.io Verifizierungs-ID ist: ${verificationID}";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "ente Weiterempfehlungs-Code: ${referralCode} \n\nEinlösen unter Einstellungen → Allgemein → Weiterempfehlungen, um ${referralStorageInGB} GB kostenlos zu erhalten, sobald Sie einen kostenpflichtigen Tarif abgeschlossen haben\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Teile mit bestimmten Personen', one: 'Teilen mit 1 Person', other: 'Teilen mit ${numberOfPeople} Personen')}";
 
-  static String m47(emailIDs) => "Geteilt mit ${emailIDs}";
+  static String m46(emailIDs) => "Geteilt mit ${emailIDs}";
 
-  static String m48(fileType) =>
+  static String m47(fileType) =>
       "Dieses ${fileType} wird von deinem Gerät gelöscht.";
 
-  static String m49(fileType) =>
+  static String m48(fileType) =>
       "Dieses ${fileType} existiert auf ente.io und deinem Gerät.";
 
-  static String m50(fileType) =>
+  static String m49(fileType) =>
       "Dieses ${fileType} wird auf ente.io gelöscht.";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m52(
+  static String m51(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
       "${usedAmount} ${usedStorageUnit} von ${totalAmount} ${totalStorageUnit} verwendet";
 
-  static String m53(id) =>
+  static String m52(id) =>
       "Ihr ${id} ist bereits mit einem anderen \'ente\'-Konto verknüpft.\nWenn Sie Ihre ${id} mit diesem Konto verwenden möchten, kontaktieren Sie bitte unseren Support\'";
 
-  static String m54(endDate) => "Ihr Abo endet am ${endDate}";
+  static String m53(endDate) => "Ihr Abo endet am ${endDate}";
 
-  static String m55(completed, total) =>
+  static String m54(completed, total) =>
       "${completed}/${total} Erinnerungsstücke gesichert";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "Diese erhalten auch ${storageAmountInGB} GB";
 
-  static String m57(email) => "Dies ist ${email}s Verifizierungs-ID";
+  static String m56(email) => "Dies ist ${email}s Verifizierungs-ID";
 
-  static String m58(count) =>
+  static String m57(count) =>
       "${Intl.plural(count, zero: '', one: '1 Tag', other: '${count} Tage')}";
 
-  static String m59(email) => "Verifiziere ${email}";
+  static String m58(email) => "Verifiziere ${email}";
 
-  static String m60(email) =>
+  static String m59(email) =>
       "Wir haben eine E-Mail an <green>${email}</green> gesendet";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: 'vor einem Jahr', other: 'vor ${count} Jahren')}";
 
-  static String m62(storageSaved) =>
+  static String m61(storageSaved) =>
       "Du hast ${storageSaved} erfolgreich freigegeben!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -738,7 +736,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Etwas ist schiefgelaufen. Bitte versuche es später noch einmal. Sollte der Fehler weiter bestehen, kontaktiere unser Supportteam."),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
                 "Elemente zeigen die Anzahl der Tage bis zum dauerhaften Löschen an"),
@@ -764,7 +761,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "linkDeviceLimit": MessageLookupByLibrary.simpleMessage("Geräte Limit"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Aktiviert"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Abgelaufen"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry":
             MessageLookupByLibrary.simpleMessage("Ablaufdatum des Links"),
         "linkHasExpired":
@@ -826,17 +823,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "maps": MessageLookupByLibrary.simpleMessage("Karten"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("Mobil, Web, Desktop"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("Mittel"),
         "monthly": MessageLookupByLibrary.simpleMessage("Monatlich"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum":
             MessageLookupByLibrary.simpleMessage("Zum Album verschieben"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash": MessageLookupByLibrary.simpleMessage(
             "In den Papierkorb verschoben"),
         "movingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
@@ -890,15 +887,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordChangedSuccessfully": MessageLookupByLibrary.simpleMessage(
             "Passwort erfolgreich geändert"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Passwort Sperre"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Wir speichern dieses Passwort nicht. Wenn du es vergisst, <underline>können wir deine Daten nicht entschlüsseln</underline>"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Zahlungsdetails"),
         "paymentFailed":
             MessageLookupByLibrary.simpleMessage("Zahlung fehlgeschlagen"),
-        "paymentFailedTalkToProvider": m33,
-        "paymentFailedWithReason": m34,
+        "paymentFailedTalkToProvider": m32,
+        "paymentFailedWithReason": m33,
         "pendingSync":
             MessageLookupByLibrary.simpleMessage("Synchronisation anstehend"),
         "peopleUsingYourCode": MessageLookupByLibrary.simpleMessage(
@@ -925,12 +922,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage(
                 "Bitte wenden Sie sich an den Support, falls das Problem weiterhin besteht"),
-        "pleaseEmailUsAt": m35,
+        "pleaseEmailUsAt": m34,
         "pleaseGrantPermissions": MessageLookupByLibrary.simpleMessage(
             "Bitte erteile die nötigen Berechtigungen"),
         "pleaseLoginAgain":
             MessageLookupByLibrary.simpleMessage("Bitte logge dich erneut ein"),
-        "pleaseSendTheLogsTo": m36,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain":
             MessageLookupByLibrary.simpleMessage("Bitte versuche es erneut"),
         "pleaseVerifyTheCodeYouHaveEntered":
@@ -963,7 +960,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "raiseTicket": MessageLookupByLibrary.simpleMessage("Ticket erstellen"),
         "rateTheApp": MessageLookupByLibrary.simpleMessage("App bewerten"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Bewerte uns"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("Wiederherstellen"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Konto wiederherstellen"),
@@ -996,7 +993,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "1. Gib diesen Code an deine Freunde"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. Sie schließen ein bezahltes Abo ab"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("Weiterempfehlungen"),
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "Einlösungen sind derzeit pausiert"),
@@ -1022,7 +1019,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeLink": MessageLookupByLibrary.simpleMessage("Link entfernen"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Teilnehmer entfernen"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Öffentlichen Link entfernen"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -1036,7 +1033,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "renameFile": MessageLookupByLibrary.simpleMessage("Datei umbenennen"),
         "renewSubscription":
             MessageLookupByLibrary.simpleMessage("Abonnement erneuern"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("Fehler melden"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Fehler melden"),
         "resendEmail":
@@ -1094,8 +1091,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
                 "Ausgewählte Elemente werden aus allen Alben gelöscht und in den Papierkorb verschoben."),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("Absenden"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("E-Mail senden"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("Einladung senden"),
@@ -1118,34 +1115,34 @@ class MessageLookup extends MessageLookupByLibrary {
         "shareAnAlbumNow":
             MessageLookupByLibrary.simpleMessage("Teile jetzt ein Album"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Link teilen"),
-        "shareMyVerificationID": m43,
+        "shareMyVerificationID": m42,
         "shareOnlyWithThePeopleYouWant": MessageLookupByLibrary.simpleMessage(
             "Teile mit ausgewählten Personen"),
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Lade ente herunter, damit wir einfach Fotos und Videos in höchster Qualität teilen können\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
             "Mit Nicht-Ente-Benutzern teilen"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("Teile dein erstes Album"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
             "Erstelle gemeinsame Alben mit anderen ente Benutzern, einschließlich solchen im kostenlosen Tarif."),
         "sharedByMe": MessageLookupByLibrary.simpleMessage("Von mir geteilt"),
         "sharedByYou": MessageLookupByLibrary.simpleMessage("Shared by you"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithMe": MessageLookupByLibrary.simpleMessage("Mit mir geteilt"),
         "sharedWithYou":
             MessageLookupByLibrary.simpleMessage("Shared with you"),
         "sharing": MessageLookupByLibrary.simpleMessage("Teilt..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "Ich stimme den <u-terms>Nutzungsbedingungen</u-terms> und der <u-policy>Datenschutzerklärung</u-policy> zu"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
             "Es wird aus allen Alben gelöscht."),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("Überspringen"),
         "social": MessageLookupByLibrary.simpleMessage("Social Media"),
         "someItemsAreInBothEnteAndYourDevice":
@@ -1186,13 +1183,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "storage": MessageLookupByLibrary.simpleMessage("Speicherplatz"),
         "storageBreakupFamily": MessageLookupByLibrary.simpleMessage("Familie"),
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("Sie"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "storageLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Speichergrenze überschritten"),
-        "storageUsageInfo": m52,
+        "storageUsageInfo": m51,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Stark"),
-        "subAlreadyLinkedErrMessage": m53,
-        "subWillBeCancelledOn": m54,
+        "subAlreadyLinkedErrMessage": m52,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("Abonnieren"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
             "Sieht aus, als sei dein Abonnement abgelaufen. Bitte abonniere, um das Teilen zu aktivieren."),
@@ -1205,7 +1202,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "suggestFeatures":
             MessageLookupByLibrary.simpleMessage("Verbesserung vorschlagen"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped":
             MessageLookupByLibrary.simpleMessage("Synchronisierung angehalten"),
         "syncing": MessageLookupByLibrary.simpleMessage("Synchronisiere …"),
@@ -1234,7 +1231,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Diese Elemente werden von deinem Gerät gelöscht."),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
             "Sie werden aus allen Alben gelöscht."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
@@ -1250,7 +1247,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Diese E-Mail-Adresse wird bereits verwendet"),
         "thisImageHasNoExifData": MessageLookupByLibrary.simpleMessage(
             "Dieses Bild hat keine Exif-Daten"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId": MessageLookupByLibrary.simpleMessage(
             "Dies ist deine Verifizierungs-ID"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1266,7 +1263,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "total": MessageLookupByLibrary.simpleMessage("Gesamt"),
         "totalSize": MessageLookupByLibrary.simpleMessage("Gesamtgröße"),
         "trash": MessageLookupByLibrary.simpleMessage("Papierkorb"),
-        "trashDaysLeft": m58,
+        "trashDaysLeft": m57,
         "tryAgain": MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
         "turnOnBackupForAutoUpload": MessageLookupByLibrary.simpleMessage(
             "Aktiviere die Sicherung, um automatisch neu hinzugefügte Dateien dieses Ordners auf ente hochzuladen."),
@@ -1325,7 +1322,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "verify": MessageLookupByLibrary.simpleMessage("Überprüfen"),
         "verifyEmail":
             MessageLookupByLibrary.simpleMessage("E-Mail-Adresse verifizieren"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Überprüfen"),
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Passwort überprüfen"),
@@ -1348,12 +1345,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage(
                 "Wir unterstützen keine Bearbeitung von Fotos und Alben, die du noch nicht besitzt"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Schwach"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Willkommen zurück!"),
         "yearly": MessageLookupByLibrary.simpleMessage("Jährlich"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("Ja"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Ja, kündigen"),
         "yesConvertToViewer": MessageLookupByLibrary.simpleMessage(
@@ -1383,7 +1380,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Du kannst nicht mit dir selbst teilen"),
         "youDontHaveAnyArchivedItems": MessageLookupByLibrary.simpleMessage(
             "Du hast keine archivierten Elemente."),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted": MessageLookupByLibrary.simpleMessage(
             "Dein Benutzerkonto wurde gelöscht"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -53,7 +53,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m10(provider) =>
       "Please contact us at support@ente.io to manage your ${provider} subscription.";
 
-  static String m63(count) =>
+  static String m62(count) =>
       "${Intl.plural(count, one: 'Delete ${count} item', other: 'Delete ${count} items')}";
 
   static String m11(currentlyDeleting, totalCount) =>
@@ -68,7 +68,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m14(count, storageSaved) =>
       "Your have cleaned up ${Intl.plural(count, one: '${count} duplicate file', other: '${count} duplicate files')}, saving (${storageSaved}!)";
 
-  static String m64(count, formattedSize) =>
+  static String m63(count, formattedSize) =>
       "${count} files, ${formattedSize} each";
 
   static String m15(newEmail) => "Email changed to ${newEmail}";
@@ -101,105 +101,103 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} item', other: '${count} items')}";
 
-  static String m26(count) => "${count} selected";
+  static String m26(expiryTime) => "Link will expire on ${expiryTime}";
 
-  static String m27(expiryTime) => "Link will expire on ${expiryTime}";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "When set to the maximum (${maxValue}), the device limit will be relaxed to allow for temporary spikes of large number of viewers.";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, zero: 'no memories', one: '${formattedCount} memory', other: '${formattedCount} memories')}";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: 'Move item', other: 'Move items')}";
 
-  static String m31(albumName) => "Moved successfully to ${albumName}";
+  static String m30(albumName) => "Moved successfully to ${albumName}";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Password strength: ${passwordStrengthValue}";
 
-  static String m33(providerName) =>
+  static String m32(providerName) =>
       "Please talk to ${providerName} support if you were charged";
 
-  static String m34(reason) =>
+  static String m33(reason) =>
       "Unfortunately your payment failed due to ${reason}";
 
-  static String m65(endDate) =>
+  static String m64(endDate) =>
       "Free trial valid till ${endDate}.\nYou can choose a paid plan afterwards.";
 
-  static String m35(toEmail) => "Please email us at ${toEmail}";
+  static String m34(toEmail) => "Please email us at ${toEmail}";
 
-  static String m36(toEmail) => "Please send the logs to \n${toEmail}";
+  static String m35(toEmail) => "Please send the logs to \n${toEmail}";
 
-  static String m37(storeName) => "Rate us on ${storeName}";
+  static String m36(storeName) => "Rate us on ${storeName}";
 
-  static String m38(storageInGB) =>
+  static String m37(storageInGB) =>
       "3. Both of you get ${storageInGB} GB* free";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} will be removed from this shared album\n\nAny photos added by them will also be removed from the album";
 
-  static String m40(endDate) => "Renews on ${endDate}";
+  static String m39(endDate) => "Renews on ${endDate}";
 
-  static String m41(count) => "${count} selected";
+  static String m40(count) => "${count} selected";
 
-  static String m42(count, yourCount) =>
+  static String m41(count, yourCount) =>
       "${count} selected (${yourCount} yours)";
 
-  static String m43(verificationID) =>
+  static String m42(verificationID) =>
       "Here\'s my verification ID: ${verificationID} for ente.io.";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "Hey, can you confirm that this is your ente.io verification ID: ${verificationID}";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "ente referral code: ${referralCode} \n\nApply it in Settings → General → Referrals to get ${referralStorageInGB} GB free after you signup for a paid plan\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Share with specific people', one: 'Shared with 1 person', other: 'Shared with ${numberOfPeople} people')}";
 
-  static String m47(emailIDs) => "Shared with ${emailIDs}";
+  static String m46(emailIDs) => "Shared with ${emailIDs}";
 
-  static String m48(fileType) =>
+  static String m47(fileType) =>
       "This ${fileType} will be deleted from your device.";
 
-  static String m49(fileType) =>
+  static String m48(fileType) =>
       "This ${fileType} is in both ente and your device.";
 
-  static String m50(fileType) => "This ${fileType} will be deleted from ente.";
+  static String m49(fileType) => "This ${fileType} will be deleted from ente.";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m52(
+  static String m51(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
       "${usedAmount} ${usedStorageUnit} of ${totalAmount} ${totalStorageUnit} used";
 
-  static String m53(id) =>
+  static String m52(id) =>
       "Your ${id} is already linked to another ente account.\nIf you would like to use your ${id} with this account, please contact our support\'\'";
 
-  static String m54(endDate) =>
+  static String m53(endDate) =>
       "Your subscription will be cancelled on ${endDate}";
 
-  static String m55(completed, total) =>
+  static String m54(completed, total) =>
       "${completed}/${total} memories preserved";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "They also get ${storageAmountInGB} GB";
 
-  static String m57(email) => "This is ${email}\'s Verification ID";
+  static String m56(email) => "This is ${email}\'s Verification ID";
 
-  static String m58(count) =>
+  static String m57(count) =>
       "${Intl.plural(count, zero: '', one: '1 day', other: '${count} days')}";
 
-  static String m59(email) => "Verify ${email}";
+  static String m58(email) => "Verify ${email}";
 
-  static String m60(email) => "We have sent a mail to <green>${email}</green>";
+  static String m59(email) => "We have sent a mail to <green>${email}</green>";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: '${count} year ago', other: '${count} years ago')}";
 
-  static String m62(storageSaved) =>
+  static String m61(storageSaved) =>
       "You have successfully freed up ${storageSaved}!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -497,7 +495,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Delete from device"),
         "deleteFromEnte":
             MessageLookupByLibrary.simpleMessage("Delete from ente"),
-        "deleteItemCount": m63,
+        "deleteItemCount": m62,
         "deleteLocation":
             MessageLookupByLibrary.simpleMessage("Delete location"),
         "deletePhotos": MessageLookupByLibrary.simpleMessage("Delete photos"),
@@ -555,7 +553,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "downloading": MessageLookupByLibrary.simpleMessage("Downloading..."),
         "dropSupportEmail": m13,
         "duplicateFileCountWithStorageSaved": m14,
-        "duplicateItemsGroup": m64,
+        "duplicateItemsGroup": m63,
         "edit": MessageLookupByLibrary.simpleMessage("Edit"),
         "editLocationTagTitle":
             MessageLookupByLibrary.simpleMessage("Edit location"),
@@ -731,7 +729,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "It looks like something went wrong. Please retry after some time. If the error persists, please contact our support team."),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
                 "Items show the number of days remaining before permanent deletion"),
@@ -755,7 +752,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "linkDeviceLimit": MessageLookupByLibrary.simpleMessage("Device limit"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Enabled"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Expired"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry": MessageLookupByLibrary.simpleMessage("Link expiry"),
         "linkHasExpired":
             MessageLookupByLibrary.simpleMessage("Link has expired"),
@@ -816,16 +813,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "maps": MessageLookupByLibrary.simpleMessage("Maps"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("Mobile, Web, Desktop"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("Moderate"),
         "monthly": MessageLookupByLibrary.simpleMessage("Monthly"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum": MessageLookupByLibrary.simpleMessage("Move to album"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash": MessageLookupByLibrary.simpleMessage("Moved to trash"),
         "movingFilesToAlbum":
             MessageLookupByLibrary.simpleMessage("Moving files to album..."),
@@ -882,14 +879,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordChangedSuccessfully": MessageLookupByLibrary.simpleMessage(
             "Password changed successfully"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Password lock"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "We don\'t store this password, so if you forget, <underline>we cannot decrypt your data</underline>"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Payment details"),
         "paymentFailed": MessageLookupByLibrary.simpleMessage("Payment failed"),
-        "paymentFailedTalkToProvider": m33,
-        "paymentFailedWithReason": m34,
+        "paymentFailedTalkToProvider": m32,
+        "paymentFailedWithReason": m33,
         "pendingSync": MessageLookupByLibrary.simpleMessage("Pending sync"),
         "peopleUsingYourCode":
             MessageLookupByLibrary.simpleMessage("People using your code"),
@@ -908,7 +905,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "pickCenterPoint":
             MessageLookupByLibrary.simpleMessage("Pick center point"),
         "pinAlbum": MessageLookupByLibrary.simpleMessage("Pin album"),
-        "playStoreFreeTrialValidTill": m65,
+        "playStoreFreeTrialValidTill": m64,
         "playstoreSubscription":
             MessageLookupByLibrary.simpleMessage("PlayStore subscription"),
         "pleaseContactSupportAndWeWillBeHappyToHelp":
@@ -917,12 +914,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage(
                 "Please contact support if the problem persists"),
-        "pleaseEmailUsAt": m35,
+        "pleaseEmailUsAt": m34,
         "pleaseGrantPermissions":
             MessageLookupByLibrary.simpleMessage("Please grant permissions"),
         "pleaseLoginAgain":
             MessageLookupByLibrary.simpleMessage("Please login again"),
-        "pleaseSendTheLogsTo": m36,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain":
             MessageLookupByLibrary.simpleMessage("Please try again"),
         "pleaseVerifyTheCodeYouHaveEntered":
@@ -955,7 +952,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "raiseTicket": MessageLookupByLibrary.simpleMessage("Raise ticket"),
         "rateTheApp": MessageLookupByLibrary.simpleMessage("Rate the app"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Rate us"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("Recover"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Recover account"),
@@ -986,7 +983,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "1. Give this code to your friends"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. They sign up for a paid plan"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("Referrals"),
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "Referrals are currently paused"),
@@ -1010,7 +1007,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeLink": MessageLookupByLibrary.simpleMessage("Remove link"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Remove participant"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Remove public link"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -1024,7 +1021,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "renameFile": MessageLookupByLibrary.simpleMessage("Rename file"),
         "renewSubscription":
             MessageLookupByLibrary.simpleMessage("Renew subscription"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("Report a bug"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Report bug"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("Resend email"),
@@ -1083,8 +1080,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
                 "Selected items will be deleted from all albums and moved to trash."),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("Send"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("Send email"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("Send invite"),
@@ -1106,16 +1103,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "shareAnAlbumNow":
             MessageLookupByLibrary.simpleMessage("Share an album now"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Share link"),
-        "shareMyVerificationID": m43,
+        "shareMyVerificationID": m42,
         "shareOnlyWithThePeopleYouWant": MessageLookupByLibrary.simpleMessage(
             "Share only with the people you want"),
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Download ente so we can easily share original quality photos and videos\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers":
             MessageLookupByLibrary.simpleMessage("Share with non-ente users"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("Share your first album"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
@@ -1126,18 +1123,18 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("New shared photos"),
         "sharedPhotoNotificationsExplanation": MessageLookupByLibrary.simpleMessage(
             "Receive notifications when someone adds a photo to a shared album that you\'re a part of"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithMe": MessageLookupByLibrary.simpleMessage("Shared with me"),
         "sharedWithYou":
             MessageLookupByLibrary.simpleMessage("Shared with you"),
         "sharing": MessageLookupByLibrary.simpleMessage("Sharing..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "I agree to the <u-terms>terms of service</u-terms> and <u-policy>privacy policy</u-policy>"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
             "It will be deleted from all albums."),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("Skip"),
         "social": MessageLookupByLibrary.simpleMessage("Social"),
         "someItemsAreInBothEnteAndYourDevice":
@@ -1174,13 +1171,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "storage": MessageLookupByLibrary.simpleMessage("Storage"),
         "storageBreakupFamily": MessageLookupByLibrary.simpleMessage("Family"),
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("You"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "storageLimitExceeded":
             MessageLookupByLibrary.simpleMessage("Storage limit exceeded"),
-        "storageUsageInfo": m52,
+        "storageUsageInfo": m51,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Strong"),
-        "subAlreadyLinkedErrMessage": m53,
-        "subWillBeCancelledOn": m54,
+        "subAlreadyLinkedErrMessage": m52,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("Subscribe"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
             "Looks like your subscription has expired. Please subscribe to enable sharing."),
@@ -1193,7 +1190,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "suggestFeatures":
             MessageLookupByLibrary.simpleMessage("Suggest features"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped": MessageLookupByLibrary.simpleMessage("Sync stopped"),
         "syncing": MessageLookupByLibrary.simpleMessage("Syncing..."),
         "systemTheme": MessageLookupByLibrary.simpleMessage("System"),
@@ -1219,7 +1216,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "These items will be deleted from your device."),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
             "They will be deleted from all albums."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
@@ -1235,7 +1232,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "This email is already in use"),
         "thisImageHasNoExifData":
             MessageLookupByLibrary.simpleMessage("This image has no exif data"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId": MessageLookupByLibrary.simpleMessage(
             "This is your Verification ID"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1252,7 +1249,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "total": MessageLookupByLibrary.simpleMessage("total"),
         "totalSize": MessageLookupByLibrary.simpleMessage("Total size"),
         "trash": MessageLookupByLibrary.simpleMessage("Trash"),
-        "trashDaysLeft": m58,
+        "trashDaysLeft": m57,
         "tryAgain": MessageLookupByLibrary.simpleMessage("Try again"),
         "turnOnBackupForAutoUpload": MessageLookupByLibrary.simpleMessage(
             "Turn on backup to automatically upload files added to this device folder to ente."),
@@ -1308,7 +1305,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Verification ID"),
         "verify": MessageLookupByLibrary.simpleMessage("Verify"),
         "verifyEmail": MessageLookupByLibrary.simpleMessage("Verify email"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Verify"),
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Verify password"),
@@ -1332,11 +1329,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage(
                 "We don\'t support editing photos and albums that you don\'t own yet"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Weak"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("Welcome back!"),
         "yearly": MessageLookupByLibrary.simpleMessage("Yearly"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("Yes"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Yes, cancel"),
         "yesConvertToViewer":
@@ -1366,7 +1363,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "You cannot share with yourself"),
         "youDontHaveAnyArchivedItems": MessageLookupByLibrary.simpleMessage(
             "You don\'t have any archived items."),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted": MessageLookupByLibrary.simpleMessage(
             "Your account has been deleted"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -98,100 +98,98 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} elemento', other: '${count} elementos')}";
 
-  static String m26(count) => "${count} seleccionados";
+  static String m26(expiryTime) => "El enlace caducará en ${expiryTime}";
 
-  static String m27(expiryTime) => "El enlace caducará en ${expiryTime}";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "Cuando se establece al máximo (${maxValue}), el límite del dispositivo se relajará para permitir picos temporales de un gran número de espectadores.";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, zero: 'no recuerdos', one: '${formattedCount} recuerdo', other: '${formattedCount} recuerdos')}\n";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: 'Mover elemento', other: 'Mover elementos')}";
 
-  static String m31(albumName) => "Movido exitosamente a ${albumName}";
+  static String m30(albumName) => "Movido exitosamente a ${albumName}";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Seguridad de la contraseña : ${passwordStrengthValue}";
 
-  static String m33(providerName) =>
+  static String m32(providerName) =>
       "Por favor hable con el soporte de ${providerName} si se le cobró";
 
-  static String m34(reason) =>
+  static String m33(reason) =>
       "Lamentablemente tu pago falló debido a ${reason}";
 
-  static String m35(toEmail) =>
+  static String m34(toEmail) =>
       "Por favor, envíanos un correo electrónico a ${toEmail}";
 
-  static String m36(toEmail) => "Por favor, envíe los registros a ${toEmail}";
+  static String m35(toEmail) => "Por favor, envíe los registros a ${toEmail}";
 
-  static String m37(storeName) => "Califícanos en ${storeName}";
+  static String m36(storeName) => "Califícanos en ${storeName}";
 
-  static String m38(storageInGB) =>
+  static String m37(storageInGB) =>
       "3. Ambos obtienen ${storageInGB} GB* gratis";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} será eliminado de este álbum compartido\n\nCualquier foto añadida por ellos también será eliminada del álbum";
 
-  static String m40(endDate) => "Se renueva el ${endDate}";
+  static String m39(endDate) => "Se renueva el ${endDate}";
 
-  static String m41(count) => "${count} seleccionados";
+  static String m40(count) => "${count} seleccionados";
 
-  static String m42(count, yourCount) =>
+  static String m41(count, yourCount) =>
       "${count} seleccionados (${yourCount} tuyos)";
 
-  static String m43(verificationID) =>
+  static String m42(verificationID) =>
       "Aquí está mi ID de verificación: ${verificationID} para ente.io.";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "Hola, ¿puedes confirmar que esta es tu ID de verificación ente.io: ${verificationID}?";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "ente código de referencia: ${referralCode} \n\nAplicarlo en Ajustes → General → Referencias para obtener ${referralStorageInGB} GB gratis después de registrarse en un plan de pago\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Compartir con personas específicas', one: 'Compartido con 1 persona', other: 'Compartido con ${numberOfPeople} personas')}";
 
-  static String m47(emailIDs) => "Compartido con ${emailIDs}";
+  static String m46(emailIDs) => "Compartido con ${emailIDs}";
 
-  static String m48(fileType) =>
+  static String m47(fileType) =>
       "Este ${fileType} se eliminará de tu dispositivo.";
 
-  static String m49(fileType) =>
+  static String m48(fileType) =>
       "Este ${fileType} está tanto en ente como en tu dispositivo.";
 
-  static String m50(fileType) => "Este ${fileType} se eliminará de ente.";
+  static String m49(fileType) => "Este ${fileType} se eliminará de ente.";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m52(
+  static String m51(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
       "${usedAmount} ${usedStorageUnit} de ${totalAmount} ${totalStorageUnit} usados";
 
-  static String m53(id) =>
+  static String m52(id) =>
       "Su ${id} ya está vinculado a otra cuenta ente.\nSi desea utilizar su ${id} con esta cuenta, póngase en contacto con nuestro servicio de asistencia\'\'";
 
-  static String m54(endDate) => "Tu suscripción se cancelará el ${endDate}";
+  static String m53(endDate) => "Tu suscripción se cancelará el ${endDate}";
 
-  static String m55(completed, total) =>
+  static String m54(completed, total) =>
       "${completed}/${total} recuerdos conservados";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "También obtienen ${storageAmountInGB} GB";
 
-  static String m57(email) => "Este es el ID de verificación de ${email}";
+  static String m56(email) => "Este es el ID de verificación de ${email}";
 
-  static String m59(email) => "Verificar ${email}";
+  static String m58(email) => "Verificar ${email}";
 
-  static String m60(email) =>
+  static String m59(email) =>
       "Hemos enviado un correo a <green>${email}</green>";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: '${count} hace un año', other: '${count} hace años')}";
 
-  static String m62(storageSaved) => "¡Has liberado ${storageSaved} con éxito!";
+  static String m61(storageSaved) => "¡Has liberado ${storageSaved} con éxito!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -697,7 +695,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Parece que algo salió mal. Por favor, vuelve a intentarlo después de algún tiempo. Si el error persiste, ponte en contacto con nuestro equipo de soporte."),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
                 "Los artículos muestran el número de días restantes antes de ser borrados permanente"),
@@ -725,7 +722,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Límite del dispositivo"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Habilitado"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Vencido"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry": MessageLookupByLibrary.simpleMessage("Enlace vence"),
         "linkHasExpired":
             MessageLookupByLibrary.simpleMessage("El enlace ha caducado"),
@@ -790,16 +787,16 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Administrar tu suscripción"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("Mercancías"),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("Celular, Web, Computadora"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("Moderada"),
         "monthly": MessageLookupByLibrary.simpleMessage("Mensual"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum": MessageLookupByLibrary.simpleMessage("Mover al álbum"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash":
             MessageLookupByLibrary.simpleMessage("Movido a la papelera"),
         "movingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
@@ -853,14 +850,14 @@ class MessageLookup extends MessageLookupByLibrary {
             "Contraseña cambiada correctamente"),
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Bloqueo por contraseña"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "No almacenamos esta contraseña, así que si la olvidas, <underline>no podemos descifrar tus datos</underline>"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Detalles de pago"),
         "paymentFailed": MessageLookupByLibrary.simpleMessage("Pago fallido"),
-        "paymentFailedTalkToProvider": m33,
-        "paymentFailedWithReason": m34,
+        "paymentFailedTalkToProvider": m32,
+        "paymentFailedWithReason": m33,
         "pendingSync":
             MessageLookupByLibrary.simpleMessage("Sincronización pendiente"),
         "peopleUsingYourCode":
@@ -887,12 +884,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage(
                 "Por favor contacte a soporte técnico si el problema persiste"),
-        "pleaseEmailUsAt": m35,
+        "pleaseEmailUsAt": m34,
         "pleaseGrantPermissions":
             MessageLookupByLibrary.simpleMessage("Por favor, concede permiso"),
         "pleaseLoginAgain": MessageLookupByLibrary.simpleMessage(
             "Por favor, vuelva a iniciar sesión"),
-        "pleaseSendTheLogsTo": m36,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain": MessageLookupByLibrary.simpleMessage(
             "Por favor, inténtalo nuevamente"),
         "pleaseVerifyTheCodeYouHaveEntered":
@@ -926,7 +923,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rateTheApp":
             MessageLookupByLibrary.simpleMessage("Evalúa la aplicación"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Califícanos"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("Recuperar"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Recuperar cuenta"),
@@ -958,7 +955,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "1. Dale este código a tus amigos"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. Se inscriben a un plan pagado"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("Referidos"),
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "Las referencias están actualmente en pausa"),
@@ -983,7 +980,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeLink": MessageLookupByLibrary.simpleMessage("Eliminar enlace"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Quitar participante"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Quitar enlace público"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -997,7 +994,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "renameFile": MessageLookupByLibrary.simpleMessage("Renombrar archivo"),
         "renewSubscription":
             MessageLookupByLibrary.simpleMessage("Renovar suscripción"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("Reportar un error"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Reportar error"),
         "resendEmail":
@@ -1057,8 +1054,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
                 "Los archivos seleccionados serán eliminados de todos los álbumes y movidos a la papelera."),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("Enviar"),
         "sendEmail":
             MessageLookupByLibrary.simpleMessage("Enviar correo electrónico"),
@@ -1083,23 +1080,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "shareAnAlbumNow":
             MessageLookupByLibrary.simpleMessage("Compartir un álbum ahora"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Compartir enlace"),
-        "shareMyVerificationID": m43,
+        "shareMyVerificationID": m42,
         "shareOnlyWithThePeopleYouWant": MessageLookupByLibrary.simpleMessage(
             "Comparte sólo con la gente que quieres"),
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Descarga ente para que podamos compartir fácilmente fotos y videos en su calidad original\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
             "Compartir con usuarios no ente"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("Comparte tu primer álbum"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
             "Crear álbumes compartidos y colaborativos con otros usuarios ente, incluyendo usuarios en planes gratuitos."),
         "sharedByMe": MessageLookupByLibrary.simpleMessage("Compartido por mí"),
         "sharedByYou": MessageLookupByLibrary.simpleMessage("Shared by you"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithMe":
             MessageLookupByLibrary.simpleMessage("Compartido conmigo"),
         "sharedWithYou":
@@ -1107,11 +1104,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Compartiendo..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "Estoy de acuerdo con los <u-terms>términos del servicio</u-terms> y <u-policy> la política de privacidad</u-policy>"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
             "Se borrará de todos los álbumes."),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("Omitir"),
         "social": MessageLookupByLibrary.simpleMessage("Social"),
         "someItemsAreInBothEnteAndYourDevice":
@@ -1146,13 +1143,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "storage": MessageLookupByLibrary.simpleMessage("Almacenamiento"),
         "storageBreakupFamily": MessageLookupByLibrary.simpleMessage("Familia"),
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("Usted"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "storageLimitExceeded":
             MessageLookupByLibrary.simpleMessage("Límite de datos excedido"),
-        "storageUsageInfo": m52,
+        "storageUsageInfo": m51,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Segura"),
-        "subAlreadyLinkedErrMessage": m53,
-        "subWillBeCancelledOn": m54,
+        "subAlreadyLinkedErrMessage": m52,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("Suscribirse"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
             "Parece que su suscripción ha caducado. Por favor, suscríbase para habilitar el compartir."),
@@ -1165,7 +1162,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "suggestFeatures":
             MessageLookupByLibrary.simpleMessage("Sugerir una característica"),
         "support": MessageLookupByLibrary.simpleMessage("Soporte"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped":
             MessageLookupByLibrary.simpleMessage("Sincronización detenida"),
         "syncing": MessageLookupByLibrary.simpleMessage("Sincronizando..."),
@@ -1193,7 +1190,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Estos elementos se eliminarán de tu dispositivo."),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
             "Se borrarán de todos los álbumes."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
@@ -1209,7 +1206,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Este correo electrónico ya está en uso"),
         "thisImageHasNoExifData": MessageLookupByLibrary.simpleMessage(
             "Esta imagen no tiene datos exif"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId": MessageLookupByLibrary.simpleMessage(
             "Esta es tu ID de verificación"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1280,7 +1277,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "verify": MessageLookupByLibrary.simpleMessage("Verificar"),
         "verifyEmail": MessageLookupByLibrary.simpleMessage(
             "Verificar correo electrónico"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Verificar"),
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Verificar contraseña"),
@@ -1303,12 +1300,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage(
                 "No admitimos la edición de fotos y álbunes que aún no son tuyos"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Poco segura"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("¡Bienvenido de nuevo!"),
         "yearly": MessageLookupByLibrary.simpleMessage("Anualmente"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("Sí"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Sí, cancelar"),
         "yesConvertToViewer":
@@ -1338,7 +1335,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "No puedes compartir contigo mismo"),
         "youDontHaveAnyArchivedItems": MessageLookupByLibrary.simpleMessage(
             "No tienes nada de elementos archivados."),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted":
             MessageLookupByLibrary.simpleMessage("Su cuenta ha sido eliminada"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -69,83 +69,81 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} objet', other: '${count} objets')}";
 
-  static String m26(count) => "${count} sélectionné";
+  static String m26(expiryTime) => "Le lien expirera le ${expiryTime}";
 
-  static String m27(expiryTime) => "Le lien expirera le ${expiryTime}";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "Lorsqu\'elle est définie au maximum (${maxValue}), la limite de l\'appareil sera assouplie pour permettre des pointes temporaires d\'un grand nombre de téléspectateurs.";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, one: '${formattedCount} mémoire', other: '${formattedCount} souvenirs')}";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: 'Déplacez l\'objet', other: 'Déplacez des objets')}";
 
-  static String m31(albumName) => "Déplacé avec succès vers ${albumName}";
+  static String m30(albumName) => "Déplacé avec succès vers ${albumName}";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Puissance du mot de passe : ${passwordStrengthValue}";
 
-  static String m35(toEmail) => "Merci de nous envoyer un e-mail à ${toEmail}";
+  static String m34(toEmail) => "Merci de nous envoyer un e-mail à ${toEmail}";
 
-  static String m36(toEmail) => "Envoyez les logs à ${toEmail}";
+  static String m35(toEmail) => "Envoyez les logs à ${toEmail}";
 
-  static String m37(storeName) => "Notez-nous sur ${storeName}";
+  static String m36(storeName) => "Notez-nous sur ${storeName}";
 
-  static String m38(storageInGB) =>
+  static String m37(storageInGB) =>
       "3. Vous recevez tous les deux ${storageInGB} GB* gratuits";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} sera retiré de cet album partagé\n\nToutes les photos ajoutées par eux seront également retirées de l\'album";
 
-  static String m40(endDate) => "Renouvellement le ${endDate}";
+  static String m39(endDate) => "Renouvellement le ${endDate}";
 
-  static String m41(count) => "${count} sélectionné";
+  static String m40(count) => "${count} sélectionné";
 
-  static String m42(count, yourCount) =>
+  static String m41(count, yourCount) =>
       "${count} sélectionné (${yourCount} votre)";
 
-  static String m43(verificationID) =>
+  static String m42(verificationID) =>
       "Voici mon ID de vérification : ${verificationID} pour ente.io.";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "Hé, pouvez-vous confirmer qu\'il s\'agit de votre ID de vérification ente.io : ${verificationID}";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "code de parrainage ente : ${referralCode} \n\nAppliquez le dans Paramètres → Général → Références pour obtenir ${referralStorageInGB} Go gratuitement après votre inscription à un plan payant\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Partagez avec des personnes spécifiques', one: 'Partagé avec 1 personne', other: 'Partagé avec ${numberOfPeople} des gens')}";
 
-  static String m47(emailIDs) => "Partagé avec ${emailIDs}";
+  static String m46(emailIDs) => "Partagé avec ${emailIDs}";
 
-  static String m48(fileType) =>
+  static String m47(fileType) =>
       "Ce ${fileType} sera supprimé de votre appareil.";
 
-  static String m49(fileType) =>
+  static String m48(fileType) =>
       "Ce ${fileType} est à la fois dans ente et votre appareil.";
 
-  static String m50(fileType) => "Ce ${fileType} sera supprimé de ente.";
+  static String m49(fileType) => "Ce ${fileType} sera supprimé de ente.";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} Go";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} Go";
 
-  static String m54(endDate) => "Votre abonnement sera annulé le ${endDate}";
+  static String m53(endDate) => "Votre abonnement sera annulé le ${endDate}";
 
-  static String m55(completed, total) =>
+  static String m54(completed, total) =>
       "${completed}/${total} souvenirs préservés";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "Ils obtiennent aussi ${storageAmountInGB} Go";
 
-  static String m57(email) => "Ceci est l\'ID de vérification de ${email}";
+  static String m56(email) => "Ceci est l\'ID de vérification de ${email}";
 
-  static String m59(email) => "Vérifier ${email}";
+  static String m58(email) => "Vérifier ${email}";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: '${count} il y a un an', other: '${count} il y a des années')}";
 
-  static String m62(storageSaved) =>
+  static String m61(storageSaved) =>
       "Vous avez libéré ${storageSaved} avec succès !";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -556,7 +554,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Il semble qu\'une erreur s\'est produite. Veuillez réessayer après un certain temps. Si l\'erreur persiste, veuillez contacter notre équipe d\'assistance."),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
                 "Les éléments montrent le nombre de jours restants avant la suppression définitive"),
@@ -579,7 +576,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Limite d\'appareil"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Activé"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Expiré"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry":
             MessageLookupByLibrary.simpleMessage("Expiration du lien"),
         "linkHasExpired":
@@ -614,15 +611,15 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Gérer l\'abonnement"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("Marchandise"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("Modéré"),
         "monthly": MessageLookupByLibrary.simpleMessage("Mensuel"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum":
             MessageLookupByLibrary.simpleMessage("Déplacer vers l\'album"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash":
             MessageLookupByLibrary.simpleMessage("Déplacé dans la corbeille"),
         "movingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
@@ -657,7 +654,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Le mot de passe a été modifié"),
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Mot de passe verrou"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Nous ne stockons pas ce mot de passe, donc si vous l\'oubliez, <underline>nous ne pouvons pas déchiffrer vos données</underline>"),
         "paymentDetails":
@@ -680,8 +677,8 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Les photos ajoutées par vous seront retirées de l\'album"),
         "playstoreSubscription":
             MessageLookupByLibrary.simpleMessage("Abonnement au PlayStore"),
-        "pleaseEmailUsAt": m35,
-        "pleaseSendTheLogsTo": m36,
+        "pleaseEmailUsAt": m34,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain":
             MessageLookupByLibrary.simpleMessage("Veuillez réessayer"),
         "pleaseWait":
@@ -701,7 +698,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Lien public activé"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Évaluez-nous"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("Restaurer"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Récupérer un compte"),
@@ -733,7 +730,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "1. Donnez ce code à vos amis"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. Ils s\'inscrivent à une offre payante"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("Parrainages"),
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "Les recommandations sont actuellement en pause"),
@@ -759,7 +756,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeLink": MessageLookupByLibrary.simpleMessage("Supprimer le lien"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Supprimer le participant"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Supprimer le lien public"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -775,7 +772,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Renommer le fichier"),
         "renewSubscription":
             MessageLookupByLibrary.simpleMessage("Renouveler l’abonnement"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("Signaler un bug"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Signaler un bug"),
         "resendEmail":
@@ -820,8 +817,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
                 "Les éléments sélectionnés seront supprimés de tous les albums et déplacés dans la corbeille."),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("Envoyer"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("Envoyer un e-mail"),
         "sendInvite":
@@ -843,31 +840,31 @@ class MessageLookup extends MessageLookupByLibrary {
         "shareAnAlbumNow": MessageLookupByLibrary.simpleMessage(
             "Partagez un album maintenant"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Partager le lien"),
-        "shareMyVerificationID": m43,
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareMyVerificationID": m42,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Téléchargez ente pour que nous puissions facilement partager des photos et des vidéos de qualité originale\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
             "Partager avec des utilisateurs non-ente"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("Share your first album"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
             "Créez des albums partagés et collaboratifs avec d\'autres utilisateurs de ente, y compris des utilisateurs sur des plans gratuits."),
         "sharedByMe": MessageLookupByLibrary.simpleMessage("Partagé par moi"),
         "sharedByYou": MessageLookupByLibrary.simpleMessage("Shared by you"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithYou":
             MessageLookupByLibrary.simpleMessage("Shared with you"),
         "sharing": MessageLookupByLibrary.simpleMessage("Partage..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "J\'accepte les <u-terms>conditions d\'utilisation</u-terms> et la <u-policy>politique de confidentialité</u-policy>"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
             "Il sera supprimé de tous les albums."),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("Ignorer"),
         "social": MessageLookupByLibrary.simpleMessage("Réseaux Sociaux"),
         "someItemsAreInBothEnteAndYourDevice":
@@ -894,9 +891,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Désolé, nous n\'avons pas pu générer de clés sécurisées sur cet appareil.\n\nVeuillez vous inscrire depuis un autre appareil."),
         "sparkleSuccess": MessageLookupByLibrary.simpleMessage("✨ Succès"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Fort"),
-        "subWillBeCancelledOn": m54,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("S\'abonner"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
             "Il semble que votre abonnement ait expiré. Veuillez vous abonner pour activer le partage."),
@@ -909,7 +906,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "suggestFeatures": MessageLookupByLibrary.simpleMessage(
             "Suggérer des fonctionnalités"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped":
             MessageLookupByLibrary.simpleMessage("Synchronisation arrêtée ?"),
         "syncing": MessageLookupByLibrary.simpleMessage(
@@ -935,7 +932,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Ces éléments seront supprimés de votre appareil."),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
             "Ils seront supprimés de tous les albums."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
@@ -947,7 +944,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Cela peut être utilisé pour récupérer votre compte si vous perdez votre deuxième facteur"),
         "thisDevice": MessageLookupByLibrary.simpleMessage("Cet appareil"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId": MessageLookupByLibrary.simpleMessage(
             "Ceci est votre ID de vérification"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1001,7 +998,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "verify": MessageLookupByLibrary.simpleMessage("Vérifier"),
         "verifyEmail":
             MessageLookupByLibrary.simpleMessage("Vérifier l\'email"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Vérifier le mot de passe"),
         "verifying":
@@ -1024,7 +1021,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("Faible"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("Bienvenue !"),
         "yearly": MessageLookupByLibrary.simpleMessage("Annuel"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("Oui"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Oui, annuler"),
         "yesConvertToViewer": MessageLookupByLibrary.simpleMessage(
@@ -1046,7 +1043,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Vous ne pouvez pas rétrograder vers cette offre"),
         "youCannotShareWithYourself": MessageLookupByLibrary.simpleMessage(
             "Vous ne pouvez pas partager avec vous-même"),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted":
             MessageLookupByLibrary.simpleMessage("Votre compte a été supprimé"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -54,7 +54,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m10(provider) =>
       "Scrivi all\'indirizzo support@ente.io per gestire il tuo abbonamento ${provider}.";
 
-  static String m63(count) =>
+  static String m62(count) =>
       "${Intl.plural(count, one: 'Elimina ${count} elemento', other: 'Elimina ${count} elementi')}";
 
   static String m11(currentlyDeleting, totalCount) =>
@@ -69,7 +69,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m14(count, storageSaved) =>
       "Hai ripulito ${Intl.plural(count, one: '${count} doppione', other: '${count} doppioni')}, salvando (${storageSaved}!)";
 
-  static String m64(count, formattedSize) =>
+  static String m63(count, formattedSize) =>
       "${count} file, ${formattedSize} l\'uno";
 
   static String m15(newEmail) => "Email cambiata in ${newEmail}";
@@ -102,105 +102,103 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} elemento', other: '${count} elementi')}";
 
-  static String m26(count) => "${count} selezionati";
+  static String m26(expiryTime) => "Il link scadrà il ${expiryTime}";
 
-  static String m27(expiryTime) => "Il link scadrà il ${expiryTime}";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "Se impostato al massimo (${maxValue}), il limite del dispositivo verrà ridotto per consentire picchi temporanei di un numero elevato di visualizzatori.";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, one: '${formattedCount} ricordo', other: '${formattedCount} ricordi')}";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: 'Sposta elemento', other: 'Sposta elementi')}";
 
-  static String m31(albumName) => "Spostato con successo su ${albumName}";
+  static String m30(albumName) => "Spostato con successo su ${albumName}";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Sicurezza password: ${passwordStrengthValue}";
 
-  static String m33(providerName) =>
+  static String m32(providerName) =>
       "Si prega di parlare con il supporto di ${providerName} se ti è stato addebitato qualcosa";
 
-  static String m34(reason) =>
+  static String m33(reason) =>
       "Purtroppo il tuo pagamento non è riuscito a causa di ${reason}";
 
-  static String m65(endDate) =>
+  static String m64(endDate) =>
       "Prova gratuita valida fino al ${endDate}.\nPuoi scegliere un piano a pagamento in seguito.";
 
-  static String m35(toEmail) => "Per favore invia un\'email a ${toEmail}";
+  static String m34(toEmail) => "Per favore invia un\'email a ${toEmail}";
 
-  static String m36(toEmail) => "Invia i log a \n${toEmail}";
+  static String m35(toEmail) => "Invia i log a \n${toEmail}";
 
-  static String m37(storeName) => "Valutaci su ${storeName}";
+  static String m36(storeName) => "Valutaci su ${storeName}";
 
-  static String m38(storageInGB) =>
+  static String m37(storageInGB) =>
       "3. Ottenete entrambi ${storageInGB} GB* gratis";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} verrà rimosso da questo album condiviso\n\nQualsiasi foto aggiunta dall\'utente verrà rimossa dall\'album";
 
-  static String m40(endDate) => "Si rinnova il ${endDate}";
+  static String m39(endDate) => "Si rinnova il ${endDate}";
 
-  static String m41(count) => "${count} selezionati";
+  static String m40(count) => "${count} selezionati";
 
-  static String m42(count, yourCount) =>
+  static String m41(count, yourCount) =>
       "${count} selezionato (${yourCount} tuoi)";
 
-  static String m43(verificationID) =>
+  static String m42(verificationID) =>
       "Ecco il mio ID di verifica: ${verificationID} per ente.io.";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "Hey, puoi confermare che questo è il tuo ID di verifica: ${verificationID} su ente.io";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "ente referral code: ${referralCode} \n\nApplicalo in Impostazioni → Generale → Referral per ottenere ${referralStorageInGB} GB gratis dopo la registrazione di un piano a pagamento\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Condividi con persone specifiche', one: 'Condividi con una persona', other: 'Condividi con ${numberOfPeople} persone')}";
 
-  static String m47(emailIDs) => "Condiviso con ${emailIDs}";
+  static String m46(emailIDs) => "Condiviso con ${emailIDs}";
 
-  static String m48(fileType) =>
+  static String m47(fileType) =>
       "Questo ${fileType} verrà eliminato dal tuo dispositivo.";
 
-  static String m49(fileType) =>
+  static String m48(fileType) =>
       "Questo ${fileType} è sia su ente che sul tuo dispositivo.";
 
-  static String m50(fileType) => "Questo ${fileType} verrà eliminato su ente.";
+  static String m49(fileType) => "Questo ${fileType} verrà eliminato su ente.";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m52(
+  static String m51(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
       "${usedAmount} ${usedStorageUnit} di ${totalAmount} ${totalStorageUnit} utilizzati";
 
-  static String m53(id) =>
+  static String m52(id) =>
       "Il tuo ${id} è già collegato ad un altro account ente.\nSe desideri utilizzare il tuo ${id} con questo account, contatta il nostro supporto\'\'";
 
-  static String m54(endDate) => "L\'abbonamento verrà cancellato il ${endDate}";
+  static String m53(endDate) => "L\'abbonamento verrà cancellato il ${endDate}";
 
-  static String m55(completed, total) =>
+  static String m54(completed, total) =>
       "${completed}/${total} ricordi conservati";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "Anche loro riceveranno ${storageAmountInGB} GB";
 
-  static String m57(email) => "Questo è l\'ID di verifica di ${email}";
+  static String m56(email) => "Questo è l\'ID di verifica di ${email}";
 
-  static String m58(count) =>
+  static String m57(count) =>
       "${Intl.plural(count, zero: '', one: '1 giorno', other: '${count} giorni')}";
 
-  static String m59(email) => "Verifica ${email}";
+  static String m58(email) => "Verifica ${email}";
 
-  static String m60(email) =>
+  static String m59(email) =>
       "Abbiamo inviato una mail a <green>${email}</green>";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: '${count} anno fa', other: '${count} anni fa')}";
 
-  static String m62(storageSaved) =>
+  static String m61(storageSaved) =>
       "Hai liberato con successo ${storageSaved}!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -503,7 +501,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Elimina dal dispositivo"),
         "deleteFromEnte":
             MessageLookupByLibrary.simpleMessage("Elimina da ente"),
-        "deleteItemCount": m63,
+        "deleteItemCount": m62,
         "deleteLocation":
             MessageLookupByLibrary.simpleMessage("Elimina posizione"),
         "deletePhotos": MessageLookupByLibrary.simpleMessage("Elimina foto"),
@@ -563,7 +561,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Scaricamento in corso..."),
         "dropSupportEmail": m13,
         "duplicateFileCountWithStorageSaved": m14,
-        "duplicateItemsGroup": m64,
+        "duplicateItemsGroup": m63,
         "edit": MessageLookupByLibrary.simpleMessage("Modifica"),
         "editLocationTagTitle":
             MessageLookupByLibrary.simpleMessage("Modifica luogo"),
@@ -742,7 +740,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Sembra che qualcosa sia andato storto. Riprova tra un po\'. Se l\'errore persiste, contatta il nostro team di supporto."),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
                 "Gli elementi mostrano il numero di giorni rimanenti prima della cancellazione permanente"),
@@ -770,7 +767,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Limite dei dispositivi"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Attivato"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Scaduto"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry": MessageLookupByLibrary.simpleMessage("Scadenza del link"),
         "linkHasExpired":
             MessageLookupByLibrary.simpleMessage("Il link è scaduto"),
@@ -835,17 +832,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "maps": MessageLookupByLibrary.simpleMessage("Mappe"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("Mobile, Web, Desktop"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("Mediocre"),
         "monthly": MessageLookupByLibrary.simpleMessage("Mensile"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum":
             MessageLookupByLibrary.simpleMessage("Sposta nell\'album"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash":
             MessageLookupByLibrary.simpleMessage("Spostato nel cestino"),
         "movingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
@@ -902,15 +899,15 @@ class MessageLookup extends MessageLookupByLibrary {
             "Password modificata con successo"),
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Blocco con password"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Noi non memorizziamo la tua password, quindi se te la dimentichi, <underline>non possiamo decriptare i tuoi dati</underline>"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Dettagli di Pagamento"),
         "paymentFailed":
             MessageLookupByLibrary.simpleMessage("Pagamento non riuscito"),
-        "paymentFailedTalkToProvider": m33,
-        "paymentFailedWithReason": m34,
+        "paymentFailedTalkToProvider": m32,
+        "paymentFailedWithReason": m33,
         "pendingSync":
             MessageLookupByLibrary.simpleMessage("Sincronizzazione in sospeso"),
         "peopleUsingYourCode": MessageLookupByLibrary.simpleMessage(
@@ -930,7 +927,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "pickCenterPoint": MessageLookupByLibrary.simpleMessage(
             "Selezionare il punto centrale"),
         "pinAlbum": MessageLookupByLibrary.simpleMessage("Fissa l\'album"),
-        "playStoreFreeTrialValidTill": m65,
+        "playStoreFreeTrialValidTill": m64,
         "playstoreSubscription":
             MessageLookupByLibrary.simpleMessage("Abbonamento su PlayStore"),
         "pleaseContactSupportAndWeWillBeHappyToHelp":
@@ -939,12 +936,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage(
                 "Riprova. Se il problema persiste, ti invitiamo a contattare l\'assistenza"),
-        "pleaseEmailUsAt": m35,
+        "pleaseEmailUsAt": m34,
         "pleaseGrantPermissions":
             MessageLookupByLibrary.simpleMessage("Concedi i permessi"),
         "pleaseLoginAgain": MessageLookupByLibrary.simpleMessage(
             "Effettua nuovamente l\'accesso"),
-        "pleaseSendTheLogsTo": m36,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain": MessageLookupByLibrary.simpleMessage("Riprova"),
         "pleaseVerifyTheCodeYouHaveEntered":
             MessageLookupByLibrary.simpleMessage(
@@ -974,7 +971,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "raiseTicket": MessageLookupByLibrary.simpleMessage("Invia ticket"),
         "rateTheApp": MessageLookupByLibrary.simpleMessage("Valuta l\'app"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Lascia una recensione"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("Recupera"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Recupera account"),
@@ -1006,7 +1003,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "1. Condividi questo codice con i tuoi amici"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. Si iscrivono per un piano a pagamento"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("Invita un Amico"),
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "I referral code sono attualmente in pausa"),
@@ -1030,7 +1027,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeLink": MessageLookupByLibrary.simpleMessage("Elimina link"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Rimuovi partecipante"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Rimuovi link pubblico"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -1044,7 +1041,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "renameFile": MessageLookupByLibrary.simpleMessage("Rinomina file"),
         "renewSubscription":
             MessageLookupByLibrary.simpleMessage("Rinnova abbonamento"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("Segnala un bug"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Segnala un bug"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("Rinvia email"),
@@ -1101,8 +1098,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
                 "Gli elementi selezionati verranno eliminati da tutti gli album e spostati nel cestino."),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("Invia"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("Invia email"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("Invita"),
@@ -1126,16 +1123,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "shareAnAlbumNow":
             MessageLookupByLibrary.simpleMessage("Condividi un album"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Condividi link"),
-        "shareMyVerificationID": m43,
+        "shareMyVerificationID": m42,
         "shareOnlyWithThePeopleYouWant": MessageLookupByLibrary.simpleMessage(
             "Condividi solo con le persone che vuoi"),
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Scarica ente in modo da poter facilmente condividere foto e video senza perdita di qualità\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
             "Condividi con utenti che non hanno un account ente"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum": MessageLookupByLibrary.simpleMessage(
             "Condividi il tuo primo album"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
@@ -1146,7 +1143,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Nuove foto condivise"),
         "sharedPhotoNotificationsExplanation": MessageLookupByLibrary.simpleMessage(
             "Ricevi notifiche quando qualcuno aggiunge una foto a un album condiviso, di cui fai parte"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithMe":
             MessageLookupByLibrary.simpleMessage("Condivisi con me"),
         "sharedWithYou":
@@ -1155,11 +1152,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Condivisione in corso..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "Accetto i <u-terms>termini di servizio</u-terms> e la <u-policy>politica sulla privacy</u-policy>"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
             "Verrà eliminato da tutti gli album."),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("Salta"),
         "social": MessageLookupByLibrary.simpleMessage("Social"),
         "someItemsAreInBothEnteAndYourDevice":
@@ -1200,13 +1197,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "storageBreakupFamily":
             MessageLookupByLibrary.simpleMessage("Famiglia"),
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("Tu"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "storageLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Limite d\'archiviazione superato"),
-        "storageUsageInfo": m52,
+        "storageUsageInfo": m51,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Forte"),
-        "subAlreadyLinkedErrMessage": m53,
-        "subWillBeCancelledOn": m54,
+        "subAlreadyLinkedErrMessage": m52,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("Iscriviti"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
             "Sembra che il tuo abbonamento sia scaduto. Iscriviti per abilitare la condivisione."),
@@ -1219,7 +1216,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "suggestFeatures":
             MessageLookupByLibrary.simpleMessage("Suggerisci una funzionalità"),
         "support": MessageLookupByLibrary.simpleMessage("Assistenza"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped":
             MessageLookupByLibrary.simpleMessage("Sincronizzazione interrotta"),
         "syncing": MessageLookupByLibrary.simpleMessage(
@@ -1248,7 +1245,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Questi file verranno eliminati dal tuo dispositivo."),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
             "Verranno eliminati da tutti gli album."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
@@ -1265,7 +1262,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Questo indirizzo email è già registrato"),
         "thisImageHasNoExifData": MessageLookupByLibrary.simpleMessage(
             "Questa immagine non ha dati EXIF"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId": MessageLookupByLibrary.simpleMessage(
             "Questo è il tuo ID di verifica"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1280,7 +1277,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "total": MessageLookupByLibrary.simpleMessage("totale"),
         "totalSize": MessageLookupByLibrary.simpleMessage("Dimensioni totali"),
         "trash": MessageLookupByLibrary.simpleMessage("Cestino"),
-        "trashDaysLeft": m58,
+        "trashDaysLeft": m57,
         "tryAgain": MessageLookupByLibrary.simpleMessage("Riprova"),
         "turnOnBackupForAutoUpload": MessageLookupByLibrary.simpleMessage(
             "Attiva il backup per caricare automaticamente i file aggiunti in questa cartella del dispositivo su ente."),
@@ -1342,7 +1339,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ID di verifica"),
         "verify": MessageLookupByLibrary.simpleMessage("Verifica"),
         "verifyEmail": MessageLookupByLibrary.simpleMessage("Verifica email"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Verifica"),
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Verifica password"),
@@ -1366,11 +1363,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage(
                 "Non puoi modificare foto e album che non possiedi"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Debole"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("Bentornato/a!"),
         "yearly": MessageLookupByLibrary.simpleMessage("Annuale"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("Si"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Sì, cancella"),
         "yesConvertToViewer": MessageLookupByLibrary.simpleMessage(
@@ -1400,7 +1397,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Non puoi condividere con te stesso"),
         "youDontHaveAnyArchivedItems": MessageLookupByLibrary.simpleMessage(
             "Non hai nulla di archiviato."),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted": MessageLookupByLibrary.simpleMessage(
             "Il tuo account è stato eliminato"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/intl/messages_nl.dart
+++ b/lib/generated/intl/messages_nl.dart
@@ -97,104 +97,102 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} item', other: '${count} items')}";
 
-  static String m26(count) => "${count} geselecteerd";
+  static String m26(expiryTime) => "Link vervalt op ${expiryTime}";
 
-  static String m27(expiryTime) => "Link vervalt op ${expiryTime}";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "Wanneer ingesteld op het maximum (${maxValue}), wordt het apparaatlimiet versoepeld om tijdelijke pieken van grote aantallen kijkers mogelijk te maken.";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, zero: 'geen herinneringen', one: '${formattedCount} herinnering', other: '${formattedCount} herinneringen')}";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: 'Bestand verplaatsen', other: 'Bestanden verplaatsen')}";
 
-  static String m31(albumName) => "Succesvol verplaatst naar ${albumName}";
+  static String m30(albumName) => "Succesvol verplaatst naar ${albumName}";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Wachtwoord sterkte: ${passwordStrengthValue}";
 
-  static String m33(providerName) =>
+  static String m32(providerName) =>
       "Praat met ${providerName} klantenservice als u in rekening bent gebracht";
 
-  static String m34(reason) =>
+  static String m33(reason) =>
       "Helaas is uw betaling mislukt vanwege ${reason}";
 
-  static String m35(toEmail) => "Stuur ons een e-mail op ${toEmail}";
+  static String m34(toEmail) => "Stuur ons een e-mail op ${toEmail}";
 
-  static String m36(toEmail) =>
+  static String m35(toEmail) =>
       "Verstuur de logboeken alstublieft naar ${toEmail}";
 
-  static String m37(storeName) => "Beoordeel ons op ${storeName}";
+  static String m36(storeName) => "Beoordeel ons op ${storeName}";
 
-  static String m38(storageInGB) =>
+  static String m37(storageInGB) =>
       "Jullie krijgen allebei ${storageInGB} GB* gratis";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} zal worden verwijderd uit dit gedeelde album\n\nAlle door hen toegevoegde foto\'s worden ook uit het album verwijderd";
 
-  static String m40(endDate) => "Wordt verlengd op ${endDate}";
+  static String m39(endDate) => "Wordt verlengd op ${endDate}";
 
-  static String m41(count) => "${count} geselecteerd";
+  static String m40(count) => "${count} geselecteerd";
 
-  static String m42(count, yourCount) =>
+  static String m41(count, yourCount) =>
       "${count} geselecteerd (${yourCount} van jou)";
 
-  static String m43(verificationID) =>
+  static String m42(verificationID) =>
       "Hier is mijn verificatie-ID: ${verificationID} voor ente.io.";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "Hey, kunt u bevestigen dat dit uw ente.io verificatie-ID is: ${verificationID}";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "ente verwijzingscode: ${referralCode} \n\nPas het toe bij Instellingen → Algemeen → Verwijzingen om ${referralStorageInGB} GB gratis te krijgen nadat je je hebt aangemeld voor een betaald abonnement\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Deel met specifieke mensen', one: 'Gedeeld met 1 persoon', other: 'Gedeeld met ${numberOfPeople} mensen')}";
 
-  static String m47(emailIDs) => "Gedeeld met ${emailIDs}";
+  static String m46(emailIDs) => "Gedeeld met ${emailIDs}";
 
-  static String m48(fileType) =>
+  static String m47(fileType) =>
       "Deze ${fileType} zal worden verwijderd van jouw apparaat.";
 
-  static String m49(fileType) =>
+  static String m48(fileType) =>
       "Deze ${fileType} staat zowel in ente als op jouw apparaat.";
 
-  static String m50(fileType) =>
+  static String m49(fileType) =>
       "Deze ${fileType} zal worden verwijderd uit ente.";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m52(
+  static String m51(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
       "${usedAmount} ${usedStorageUnit} van ${totalAmount} ${totalStorageUnit} gebruikt";
 
-  static String m53(id) =>
+  static String m52(id) =>
       "Uw ${id} is al aan een ander ente account gekoppeld.\nAls u uw ${id} wilt gebruiken met dit account, neem dan contact op met onze klantenservice";
 
-  static String m54(endDate) => "Uw abonnement loopt af op ${endDate}";
+  static String m53(endDate) => "Uw abonnement loopt af op ${endDate}";
 
-  static String m55(completed, total) =>
+  static String m54(completed, total) =>
       "${completed}/${total} herinneringen bewaard";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "Zij krijgen ook ${storageAmountInGB} GB";
 
-  static String m57(email) => "Dit is de verificatie-ID van ${email}";
+  static String m56(email) => "Dit is de verificatie-ID van ${email}";
 
-  static String m58(count) =>
+  static String m57(count) =>
       "${Intl.plural(count, zero: '', one: '1 dag', other: '${count} dagen')}";
 
-  static String m59(email) => "Verifieer ${email}";
+  static String m58(email) => "Verifieer ${email}";
 
-  static String m60(email) =>
+  static String m59(email) =>
       "We hebben een e-mail gestuurd naar <green>${email}</green>";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: '${count} jaar geleden', other: '${count} jaar geleden')}";
 
-  static String m62(storageSaved) =>
+  static String m61(storageSaved) =>
       "Je hebt ${storageSaved} succesvol vrijgemaakt!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -731,7 +729,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Het lijkt erop dat er iets fout is gegaan. Probeer het later opnieuw. Als de fout zich blijft voordoen, neem dan contact op met ons supportteam."),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
                 "Bestanden tonen het aantal resterende dagen voordat ze permanent worden verwijderd"),
@@ -757,7 +754,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Apparaat limiet"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Ingeschakeld"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Verlopen"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry": MessageLookupByLibrary.simpleMessage("Vervaldatum"),
         "linkHasExpired":
             MessageLookupByLibrary.simpleMessage("Link is vervallen"),
@@ -817,17 +814,17 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Abonnement beheren"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("Mobiel, Web, Desktop"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("Matig"),
         "monthly": MessageLookupByLibrary.simpleMessage("Maandelijks"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum":
             MessageLookupByLibrary.simpleMessage("Verplaats naar album"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash":
             MessageLookupByLibrary.simpleMessage("Naar prullenbak verplaatst"),
         "movingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
@@ -880,15 +877,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordChangedSuccessfully": MessageLookupByLibrary.simpleMessage(
             "Wachtwoord succesvol aangepast"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Wachtwoord slot"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Wij slaan dit wachtwoord niet op, dus als je het vergeet, kunnen <underline>we je gegevens niet ontsleutelen</underline>"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Betaalgegevens"),
         "paymentFailed":
             MessageLookupByLibrary.simpleMessage("Betaling mislukt"),
-        "paymentFailedTalkToProvider": m33,
-        "paymentFailedWithReason": m34,
+        "paymentFailedTalkToProvider": m32,
+        "paymentFailedWithReason": m33,
         "pendingSync": MessageLookupByLibrary.simpleMessage(
             "Synchronisatie in behandeling"),
         "peopleUsingYourCode": MessageLookupByLibrary.simpleMessage(
@@ -915,12 +912,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage(
                 "Neem contact op met klantenservice als het probleem aanhoudt"),
-        "pleaseEmailUsAt": m35,
+        "pleaseEmailUsAt": m34,
         "pleaseGrantPermissions": MessageLookupByLibrary.simpleMessage(
             "Geef alstublieft toestemming"),
         "pleaseLoginAgain":
             MessageLookupByLibrary.simpleMessage("Log opnieuw in"),
-        "pleaseSendTheLogsTo": m36,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain":
             MessageLookupByLibrary.simpleMessage("Probeer het nog eens"),
         "pleaseVerifyTheCodeYouHaveEntered":
@@ -952,7 +949,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "raiseTicket": MessageLookupByLibrary.simpleMessage("Meld probleem"),
         "rateTheApp": MessageLookupByLibrary.simpleMessage("Beoordeel de app"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Beoordeel ons"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("Herstellen"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Account herstellen"),
@@ -983,7 +980,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "1. Geef deze code aan je vrienden"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. Ze registreren voor een betaald plan"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("Referenties"),
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "Verwijzingen zijn momenteel gepauzeerd"),
@@ -1009,7 +1006,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeLink": MessageLookupByLibrary.simpleMessage("Verwijder link"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Deelnemer verwijderen"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Verwijder publieke link"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -1025,7 +1022,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Bestandsnaam wijzigen"),
         "renewSubscription":
             MessageLookupByLibrary.simpleMessage("Abonnement verlengen"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("Een fout melden"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Fout melden"),
         "resendEmail":
@@ -1082,8 +1079,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
                 "Geselecteerde bestanden worden verwijderd uit alle albums en verplaatst naar de prullenbak."),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("Verzenden"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("E-mail versturen"),
         "sendInvite":
@@ -1106,34 +1103,34 @@ class MessageLookup extends MessageLookupByLibrary {
         "shareAnAlbumNow":
             MessageLookupByLibrary.simpleMessage("Deel nu een album"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Link delen"),
-        "shareMyVerificationID": m43,
+        "shareMyVerificationID": m42,
         "shareOnlyWithThePeopleYouWant": MessageLookupByLibrary.simpleMessage(
             "Deel alleen met de mensen die u wilt"),
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Download ente zodat we gemakkelijk foto\'s en video\'s van originele kwaliteit kunnen delen\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
             "Delen met niet-ente gebruikers"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("Deel jouw eerste album"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
             "Maak gedeelde en collaboratieve albums met andere ente gebruikers, inclusief gebruikers met gratis abonnementen."),
         "sharedByMe": MessageLookupByLibrary.simpleMessage("Gedeeld door mij"),
         "sharedByYou": MessageLookupByLibrary.simpleMessage("Shared by you"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithMe": MessageLookupByLibrary.simpleMessage("Gedeeld met mij"),
         "sharedWithYou":
             MessageLookupByLibrary.simpleMessage("Shared with you"),
         "sharing": MessageLookupByLibrary.simpleMessage("Delen..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "Ik ga akkoord met de <u-terms>gebruiksvoorwaarden</u-terms> en <u-policy>privacybeleid</u-policy>"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
             "Het wordt uit alle albums verwijderd."),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("Overslaan"),
         "social": MessageLookupByLibrary.simpleMessage("Sociale media"),
         "someItemsAreInBothEnteAndYourDevice": MessageLookupByLibrary.simpleMessage(
@@ -1170,13 +1167,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "storage": MessageLookupByLibrary.simpleMessage("Opslagruimte"),
         "storageBreakupFamily": MessageLookupByLibrary.simpleMessage("Familie"),
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("Jij"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "storageLimitExceeded":
             MessageLookupByLibrary.simpleMessage("Opslaglimiet overschreden"),
-        "storageUsageInfo": m52,
+        "storageUsageInfo": m51,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Sterk"),
-        "subAlreadyLinkedErrMessage": m53,
-        "subWillBeCancelledOn": m54,
+        "subAlreadyLinkedErrMessage": m52,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("Abonneer"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
             "Het lijkt erop dat je abonnement is verlopen. Abonneer om delen mogelijk te maken."),
@@ -1189,7 +1186,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "suggestFeatures":
             MessageLookupByLibrary.simpleMessage("Features voorstellen"),
         "support": MessageLookupByLibrary.simpleMessage("Ondersteuning"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped":
             MessageLookupByLibrary.simpleMessage("Synchronisatie gestopt"),
         "syncing": MessageLookupByLibrary.simpleMessage("Synchroniseren..."),
@@ -1217,7 +1214,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Deze bestanden zullen worden verwijderd van uw apparaat."),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
             "Ze zullen uit alle albums worden verwijderd."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
@@ -1233,7 +1230,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Dit e-mailadres is al in gebruik"),
         "thisImageHasNoExifData": MessageLookupByLibrary.simpleMessage(
             "Deze foto heeft geen exif gegevens"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId":
             MessageLookupByLibrary.simpleMessage("Dit is uw verificatie-ID"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1249,7 +1246,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "total": MessageLookupByLibrary.simpleMessage("totaal"),
         "totalSize": MessageLookupByLibrary.simpleMessage("Totale grootte"),
         "trash": MessageLookupByLibrary.simpleMessage("Prullenbak"),
-        "trashDaysLeft": m58,
+        "trashDaysLeft": m57,
         "tryAgain": MessageLookupByLibrary.simpleMessage("Probeer opnieuw"),
         "turnOnBackupForAutoUpload": MessageLookupByLibrary.simpleMessage(
             "Schakel back-up in om bestanden die toegevoegd zijn aan deze map op dit apparaat automatisch te uploaden."),
@@ -1308,7 +1305,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Verificatie ID"),
         "verify": MessageLookupByLibrary.simpleMessage("Verifiëren"),
         "verifyEmail": MessageLookupByLibrary.simpleMessage("Bevestig e-mail"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Verifiëren"),
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Bevestig wachtwoord"),
@@ -1331,11 +1328,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage(
                 "We ondersteunen het bewerken van foto\'s en albums waar je niet de eigenaar van bent nog niet"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Zwak"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("Welkom terug!"),
         "yearly": MessageLookupByLibrary.simpleMessage("Jaarlijks"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("Ja"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Ja, opzeggen"),
         "yesConvertToViewer":
@@ -1365,7 +1362,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Je kunt niet met jezelf delen"),
         "youDontHaveAnyArchivedItems": MessageLookupByLibrary.simpleMessage(
             "U heeft geen gearchiveerde bestanden."),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted":
             MessageLookupByLibrary.simpleMessage("Je account is verwijderd"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -20,7 +20,7 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'pl';
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Siła hasła: ${passwordStrengthValue}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -124,7 +124,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "password": MessageLookupByLibrary.simpleMessage("Hasło"),
         "passwordChangedSuccessfully": MessageLookupByLibrary.simpleMessage(
             "Hasło zostało pomyślnie zmienione"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Nie przechowujemy tego hasła, więc jeśli go zapomnisz, <underline>nie będziemy w stanie odszyfrować Twoich danych</underline>"),
         "pleaseTryAgain":

--- a/lib/generated/intl/messages_pt.dart
+++ b/lib/generated/intl/messages_pt.dart
@@ -40,23 +40,23 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m19(storageAmountInGB) =>
       "${storageAmountInGB} GB cada vez que alguém se inscrever para um plano pago e aplica o seu código";
 
-  static String m32(passwordStrengthValue) =>
+  static String m31(passwordStrengthValue) =>
       "Segurança da senha: ${passwordStrengthValue}";
 
-  static String m38(storageInGB) => "3. Ambos ganham ${storageInGB} GB* grátis";
+  static String m37(storageInGB) => "3. Ambos ganham ${storageInGB} GB* grátis";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} será removido deste álbum compartilhado\n\nQuaisquer fotos adicionadas por eles também serão removidas do álbum";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "Código de referência do ente: ${referralCode} \n\nAplique em Configurações → Geral → Indicações para obter ${referralStorageInGB} GB gratuitamente após a sua inscrição em um plano pago\n\nhttps://ente.io";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m56(storageAmountInGB) =>
+  static String m55(storageAmountInGB) =>
       "Eles também recebem ${storageAmountInGB} GB";
 
-  static String m60(email) => "Enviamos um e-mail à <green>${email}</green>";
+  static String m59(email) => "Enviamos um e-mail à <green>${email}</green>";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -280,7 +280,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Senha alterada com sucesso"),
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Bloqueio de senha"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Nós não salvamos essa senha, se você esquecer <underline> nós não poderemos descriptografar seus dados</underline>"),
         "peopleUsingYourCode":
@@ -319,7 +319,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Envie esse código aos seus amigos"),
         "referralStep2": MessageLookupByLibrary.simpleMessage(
             "2. Eles se inscrevem em um plano pago"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
             "Referências estão atualmente pausadas"),
         "remove": MessageLookupByLibrary.simpleMessage("Remover"),
@@ -329,7 +329,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Remover do álbum?"),
         "removeParticipant":
             MessageLookupByLibrary.simpleMessage("Remover participante"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink":
             MessageLookupByLibrary.simpleMessage("Remover link público"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
@@ -356,7 +356,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Chave: definaSenha\n→ definaSenha"),
         "setupComplete":
             MessageLookupByLibrary.simpleMessage("Configuração concluída"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("Share your first album"),
         "sharedByYou": MessageLookupByLibrary.simpleMessage("Shared by you"),
@@ -377,7 +377,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "sorryWeCouldNotGenerateSecureKeysOnThisDevicennplease":
             MessageLookupByLibrary.simpleMessage(
                 "Desculpe, não foi possível gerar chaves seguras neste dispositivo.\n\npor favor, faça o login com um dispositivo diferente."),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "strongStrength": MessageLookupByLibrary.simpleMessage("Forte"),
         "subscribe": MessageLookupByLibrary.simpleMessage("Inscrever-se"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
@@ -389,7 +389,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "terminateSession":
             MessageLookupByLibrary.simpleMessage("Encerrar sessão?"),
         "termsOfServicesTitle": MessageLookupByLibrary.simpleMessage("Termos"),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "thisCanBeUsedToRecoverYourAccountIfYou":
             MessageLookupByLibrary.simpleMessage(
                 "Isso pode ser usado para recuperar sua conta se você perder seu segundo fator"),
@@ -422,7 +422,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "viewRecoveryKey":
             MessageLookupByLibrary.simpleMessage("Ver chave de recuperação"),
         "viewer": MessageLookupByLibrary.simpleMessage("Visualizador"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Fraca"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Bem-vindo de volta!"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -90,91 +90,89 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m25(count) =>
       "${Intl.plural(count, one: '${count} 个项目', other: '${count} 个项目')}";
 
-  static String m26(count) => "已选择 ${count} 个";
+  static String m26(expiryTime) => "链接将在 ${expiryTime} 过期";
 
-  static String m27(expiryTime) => "链接将在 ${expiryTime} 过期";
-
-  static String m28(maxValue) =>
+  static String m27(maxValue) =>
       "当设置为最大值 (${maxValue}) 时，设备限制将放宽以允许大量查看者查看的临时高峰。";
 
-  static String m29(count, formattedCount) =>
+  static String m28(count, formattedCount) =>
       "${Intl.plural(count, zero: '没有回忆', one: '${formattedCount} 个回忆', other: '${formattedCount} 个回忆')}";
 
-  static String m30(count) =>
+  static String m29(count) =>
       "${Intl.plural(count, one: '移动一个项目', other: '移动一些项目')}";
 
-  static String m31(albumName) => "成功移动到 ${albumName}";
+  static String m30(albumName) => "成功移动到 ${albumName}";
 
-  static String m32(passwordStrengthValue) => "密码强度： ${passwordStrengthValue}";
+  static String m31(passwordStrengthValue) => "密码强度： ${passwordStrengthValue}";
 
-  static String m33(providerName) => "如果您被收取费用，请用英语与 ${providerName} 的客服聊天";
+  static String m32(providerName) => "如果您被收取费用，请用英语与 ${providerName} 的客服聊天";
 
-  static String m34(reason) => "很抱歉，您的支付因 ${reason} 而失败";
+  static String m33(reason) => "很抱歉，您的支付因 ${reason} 而失败";
 
-  static String m35(toEmail) => "请给我们发送电子邮件至 ${toEmail}";
+  static String m34(toEmail) => "请给我们发送电子邮件至 ${toEmail}";
 
-  static String m36(toEmail) => "请将日志发送至 \n${toEmail}";
+  static String m35(toEmail) => "请将日志发送至 \n${toEmail}";
 
-  static String m37(storeName) => "在 ${storeName} 上给我们评分";
+  static String m36(storeName) => "在 ${storeName} 上给我们评分";
 
-  static String m38(storageInGB) => "3. 你都可以免费获得 ${storageInGB} GB*";
+  static String m37(storageInGB) => "3. 你都可以免费获得 ${storageInGB} GB*";
 
-  static String m39(userEmail) =>
+  static String m38(userEmail) =>
       "${userEmail} 将从这个共享相册中删除\n\nTA们添加的任何照片也将从相册中删除";
 
-  static String m40(endDate) => "在 ${endDate} 前续费";
+  static String m39(endDate) => "在 ${endDate} 前续费";
 
-  static String m41(count) => "已选择 ${count} 个";
+  static String m40(count) => "已选择 ${count} 个";
 
-  static String m42(count, yourCount) => "选择了 ${count} 个 (您的 ${yourCount} 个)";
+  static String m41(count, yourCount) => "选择了 ${count} 个 (您的 ${yourCount} 个)";
 
-  static String m43(verificationID) => "这是我的ente.io 的验证 ID： ${verificationID}。";
+  static String m42(verificationID) => "这是我的ente.io 的验证 ID： ${verificationID}。";
 
-  static String m44(verificationID) =>
+  static String m43(verificationID) =>
       "嘿，你能确认这是你的 ente.io 验证 ID：${verificationID}";
 
-  static String m45(referralCode, referralStorageInGB) =>
+  static String m44(referralCode, referralStorageInGB) =>
       "ente转发码: ${referralCode} \n\n在设置 → 常规 → 推荐中应用它以在注册付费计划后可以免费获得 ${referralStorageInGB} GB\n\nhttps://ente.io";
 
-  static String m46(numberOfPeople) =>
+  static String m45(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: '与特定人员共享', one: '与 1 人共享', other: '与 ${numberOfPeople} 人共享')}";
 
-  static String m47(emailIDs) => "与 ${emailIDs} 共享";
+  static String m46(emailIDs) => "与 ${emailIDs} 共享";
 
-  static String m48(fileType) => "此 ${fileType} 将从您的设备中删除。";
+  static String m47(fileType) => "此 ${fileType} 将从您的设备中删除。";
 
-  static String m49(fileType) => "此 ${fileType} 同时在ente和您的设备中。";
+  static String m48(fileType) => "此 ${fileType} 同时在ente和您的设备中。";
 
-  static String m50(fileType) => "此 ${fileType} 将从ente中删除。";
+  static String m49(fileType) => "此 ${fileType} 将从ente中删除。";
 
-  static String m51(storageAmountInGB) => "${storageAmountInGB} GB";
+  static String m50(storageAmountInGB) => "${storageAmountInGB} GB";
 
-  static String m52(
+  static String m51(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
       "已使用 ${usedAmount} ${usedStorageUnit} / ${totalAmount} ${totalStorageUnit}";
 
-  static String m53(id) =>
+  static String m52(id) =>
       "您的 ${id} 已经链接到另一个ente账户。\n如果您想要通过此账户使用您的 ${id} ，请联系我们的客服\'\'";
 
-  static String m54(endDate) => "您的订阅将于 ${endDate} 取消";
+  static String m53(endDate) => "您的订阅将于 ${endDate} 取消";
 
-  static String m55(completed, total) => "已保存的回忆 ${completed}/共 ${total}";
+  static String m54(completed, total) => "已保存的回忆 ${completed}/共 ${total}";
 
-  static String m56(storageAmountInGB) => "他们也会获得 ${storageAmountInGB} GB";
+  static String m55(storageAmountInGB) => "他们也会获得 ${storageAmountInGB} GB";
 
-  static String m57(email) => "这是 ${email} 的验证ID";
+  static String m56(email) => "这是 ${email} 的验证ID";
 
-  static String m58(count) =>
+  static String m57(count) =>
       "${Intl.plural(count, zero: '', one: '1天', other: '${count} 天')}";
 
-  static String m59(email) => "验证 ${email}";
+  static String m58(email) => "验证 ${email}";
 
-  static String m60(email) => "我们已经发送邮件到 <green>${email}</green>";
+  static String m59(email) => "我们已经发送邮件到 <green>${email}</green>";
 
-  static String m61(count) =>
+  static String m60(count) =>
       "${Intl.plural(count, one: '${count} 年前', other: '${count} 年前')}";
 
-  static String m62(storageSaved) => "您已成功释放了 ${storageSaved}！";
+  static String m61(storageSaved) => "您已成功释放了 ${storageSaved}！";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -594,7 +592,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "看起来出了点问题。 请稍后重试。 如果错误仍然存在，请联系我们的支持团队。"),
         "itemCount": m25,
-        "itemSelectedCount": m26,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage("项目显示永久删除前剩余的天数"),
         "itemsWillBeRemovedFromAlbum":
@@ -616,7 +613,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "linkDeviceLimit": MessageLookupByLibrary.simpleMessage("设备限制"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("已启用"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("已过期"),
-        "linkExpiresOn": m27,
+        "linkExpiresOn": m26,
         "linkExpiry": MessageLookupByLibrary.simpleMessage("链接过期"),
         "linkHasExpired": MessageLookupByLibrary.simpleMessage("链接已过期"),
         "linkNeverExpires": MessageLookupByLibrary.simpleMessage("永不"),
@@ -667,16 +664,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "manageSubscription": MessageLookupByLibrary.simpleMessage("管理订阅"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "maxDeviceLimitSpikeHandling": m28,
-        "memoryCount": m29,
+        "maxDeviceLimitSpikeHandling": m27,
+        "memoryCount": m28,
         "merchandise": MessageLookupByLibrary.simpleMessage("商品"),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("移动端, 网页端, 桌面端"),
         "moderateStrength": MessageLookupByLibrary.simpleMessage("中等"),
         "monthly": MessageLookupByLibrary.simpleMessage("每月"),
-        "moveItem": m30,
+        "moveItem": m29,
         "moveToAlbum": MessageLookupByLibrary.simpleMessage("移动到相册"),
-        "movedSuccessfullyTo": m31,
+        "movedSuccessfullyTo": m30,
         "movedToTrash": MessageLookupByLibrary.simpleMessage("已移至回收站"),
         "movingFilesToAlbum":
             MessageLookupByLibrary.simpleMessage("正在将文件移动到相册..."),
@@ -722,13 +719,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordChangedSuccessfully":
             MessageLookupByLibrary.simpleMessage("密码修改成功"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("密码锁"),
-        "passwordStrength": m32,
+        "passwordStrength": m31,
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "我们不储存这个密码，所以如果忘记， <underline>我们不能解密您的数据</underline>"),
         "paymentDetails": MessageLookupByLibrary.simpleMessage("付款明细"),
         "paymentFailed": MessageLookupByLibrary.simpleMessage("支付失败"),
-        "paymentFailedTalkToProvider": m33,
-        "paymentFailedWithReason": m34,
+        "paymentFailedTalkToProvider": m32,
+        "paymentFailedWithReason": m33,
         "pendingSync": MessageLookupByLibrary.simpleMessage("正在等待同步"),
         "peopleUsingYourCode": MessageLookupByLibrary.simpleMessage("使用您的代码的人"),
         "permDeleteWarning":
@@ -748,10 +745,10 @@ class MessageLookup extends MessageLookupByLibrary {
                 "请用英语联系 support@ente.io ，我们将乐意提供帮助！"),
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage("如果问题仍然存在，请联系支持"),
-        "pleaseEmailUsAt": m35,
+        "pleaseEmailUsAt": m34,
         "pleaseGrantPermissions": MessageLookupByLibrary.simpleMessage("请授予权限"),
         "pleaseLoginAgain": MessageLookupByLibrary.simpleMessage("请重新登录"),
-        "pleaseSendTheLogsTo": m36,
+        "pleaseSendTheLogsTo": m35,
         "pleaseTryAgain": MessageLookupByLibrary.simpleMessage("请重试"),
         "pleaseVerifyTheCodeYouHaveEntered":
             MessageLookupByLibrary.simpleMessage("请验证您输入的代码"),
@@ -774,7 +771,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "raiseTicket": MessageLookupByLibrary.simpleMessage("提升工单"),
         "rateTheApp": MessageLookupByLibrary.simpleMessage("为此应用评分"),
         "rateUs": MessageLookupByLibrary.simpleMessage("给我们评分"),
-        "rateUsOnStore": m37,
+        "rateUsOnStore": m36,
         "recover": MessageLookupByLibrary.simpleMessage("恢复"),
         "recoverAccount": MessageLookupByLibrary.simpleMessage("恢复账户"),
         "recoverButton": MessageLookupByLibrary.simpleMessage("恢复"),
@@ -799,7 +796,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("推荐朋友和 2 倍您的计划"),
         "referralStep1": MessageLookupByLibrary.simpleMessage("1. 将此代码提供给您的朋友"),
         "referralStep2": MessageLookupByLibrary.simpleMessage("2. 他们注册一个付费计划"),
-        "referralStep3": m38,
+        "referralStep3": m37,
         "referrals": MessageLookupByLibrary.simpleMessage("推荐人"),
         "referralsAreCurrentlyPaused":
             MessageLookupByLibrary.simpleMessage("推荐已暂停"),
@@ -818,7 +815,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeFromFavorite": MessageLookupByLibrary.simpleMessage("从收藏中移除"),
         "removeLink": MessageLookupByLibrary.simpleMessage("移除链接"),
         "removeParticipant": MessageLookupByLibrary.simpleMessage("移除参与者"),
-        "removeParticipantBody": m39,
+        "removeParticipantBody": m38,
         "removePublicLink": MessageLookupByLibrary.simpleMessage("删除公开链接"),
         "removeShareItemsWarning":
             MessageLookupByLibrary.simpleMessage("您要删除的某些项目是由其他人添加的，您将无法访问它们"),
@@ -829,7 +826,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "renameAlbum": MessageLookupByLibrary.simpleMessage("重命名相册"),
         "renameFile": MessageLookupByLibrary.simpleMessage("重命名文件"),
         "renewSubscription": MessageLookupByLibrary.simpleMessage("续费订阅"),
-        "renewsOn": m40,
+        "renewsOn": m39,
         "reportABug": MessageLookupByLibrary.simpleMessage("报告错误"),
         "reportBug": MessageLookupByLibrary.simpleMessage("报告错误"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("重新发送电子邮件"),
@@ -872,8 +869,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("所选文件夹将被加密和备份"),
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage("所选项目将从所有相册中删除并移动到回收站。"),
-        "selectedPhotos": m41,
-        "selectedPhotosWithYours": m42,
+        "selectedPhotos": m40,
+        "selectedPhotosWithYours": m41,
         "send": MessageLookupByLibrary.simpleMessage("发送"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("发送电子邮件"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("发送邀请"),
@@ -891,34 +888,34 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("打开相册并点击右上角的分享按钮进行分享"),
         "shareAnAlbumNow": MessageLookupByLibrary.simpleMessage("立即分享相册"),
         "shareLink": MessageLookupByLibrary.simpleMessage("分享链接"),
-        "shareMyVerificationID": m43,
+        "shareMyVerificationID": m42,
         "shareOnlyWithThePeopleYouWant":
             MessageLookupByLibrary.simpleMessage("仅与您想要的人分享"),
-        "shareTextConfirmOthersVerificationID": m44,
+        "shareTextConfirmOthersVerificationID": m43,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "下载 ente，以便我们轻松分享原始质量的照片和视频\n\nhttps://ente.io"),
-        "shareTextReferralCode": m45,
+        "shareTextReferralCode": m44,
         "shareWithNonenteUsers":
             MessageLookupByLibrary.simpleMessage("与非ente 用户分享"),
-        "shareWithPeopleSectionTitle": m46,
+        "shareWithPeopleSectionTitle": m45,
         "shareYourFirstAlbum":
             MessageLookupByLibrary.simpleMessage("分享您的第一个相册"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
             "与其他ente用户创建共享和协作相册，包括免费计划的用户。"),
         "sharedByMe": MessageLookupByLibrary.simpleMessage("由我共享的"),
         "sharedByYou": MessageLookupByLibrary.simpleMessage("Shared by you"),
-        "sharedWith": m47,
+        "sharedWith": m46,
         "sharedWithMe": MessageLookupByLibrary.simpleMessage("与我共享"),
         "sharedWithYou":
             MessageLookupByLibrary.simpleMessage("Shared with you"),
         "sharing": MessageLookupByLibrary.simpleMessage("正在分享..."),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "我同意 <u-terms>服务条款</u-terms> 和 <u-policy>隐私政策</u-policy>"),
-        "singleFileDeleteFromDevice": m48,
+        "singleFileDeleteFromDevice": m47,
         "singleFileDeleteHighlight":
             MessageLookupByLibrary.simpleMessage("它将从所有相册中删除。"),
-        "singleFileInBothLocalAndRemote": m49,
-        "singleFileInRemoteOnly": m50,
+        "singleFileInBothLocalAndRemote": m48,
+        "singleFileInRemoteOnly": m49,
         "skip": MessageLookupByLibrary.simpleMessage("略过"),
         "social": MessageLookupByLibrary.simpleMessage("社交"),
         "someItemsAreInBothEnteAndYourDevice":
@@ -948,12 +945,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "storage": MessageLookupByLibrary.simpleMessage("存储空间"),
         "storageBreakupFamily": MessageLookupByLibrary.simpleMessage("家庭"),
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("您"),
-        "storageInGB": m51,
+        "storageInGB": m50,
         "storageLimitExceeded": MessageLookupByLibrary.simpleMessage("已超出存储限制"),
-        "storageUsageInfo": m52,
+        "storageUsageInfo": m51,
         "strongStrength": MessageLookupByLibrary.simpleMessage("强"),
-        "subAlreadyLinkedErrMessage": m53,
-        "subWillBeCancelledOn": m54,
+        "subAlreadyLinkedErrMessage": m52,
+        "subWillBeCancelledOn": m53,
         "subscribe": MessageLookupByLibrary.simpleMessage("订阅"),
         "subscribeToEnableSharing":
             MessageLookupByLibrary.simpleMessage("您的订阅似乎已过期。请订阅以启用分享。"),
@@ -964,7 +961,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("取消归档成功"),
         "suggestFeatures": MessageLookupByLibrary.simpleMessage("建议新功能"),
         "support": MessageLookupByLibrary.simpleMessage("支持"),
-        "syncProgress": m55,
+        "syncProgress": m54,
         "syncStopped": MessageLookupByLibrary.simpleMessage("同步已停止"),
         "syncing": MessageLookupByLibrary.simpleMessage("正在同步···"),
         "systemTheme": MessageLookupByLibrary.simpleMessage("系统"),
@@ -987,7 +984,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "theme": MessageLookupByLibrary.simpleMessage("主题"),
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage("这些项目将从您的设备中删除。"),
-        "theyAlsoGetXGb": m56,
+        "theyAlsoGetXGb": m55,
         "theyWillBeDeletedFromAllAlbums":
             MessageLookupByLibrary.simpleMessage("他们将从所有相册中删除。"),
         "thisActionCannotBeUndone":
@@ -1001,7 +998,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("这个邮箱地址已经被使用"),
         "thisImageHasNoExifData":
             MessageLookupByLibrary.simpleMessage("此图像没有Exif 数据"),
-        "thisIsPersonVerificationId": m57,
+        "thisIsPersonVerificationId": m56,
         "thisIsYourVerificationId":
             MessageLookupByLibrary.simpleMessage("这是您的验证 ID"),
         "thisWillLogYouOutOfTheFollowingDevice":
@@ -1014,7 +1011,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "total": MessageLookupByLibrary.simpleMessage("总计"),
         "totalSize": MessageLookupByLibrary.simpleMessage("总大小"),
         "trash": MessageLookupByLibrary.simpleMessage("回收站"),
-        "trashDaysLeft": m58,
+        "trashDaysLeft": m57,
         "tryAgain": MessageLookupByLibrary.simpleMessage("请再试一次"),
         "turnOnBackupForAutoUpload":
             MessageLookupByLibrary.simpleMessage("打开备份以自动上传添加到此设备文件夹的文件。"),
@@ -1058,7 +1055,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "verificationId": MessageLookupByLibrary.simpleMessage("验证 ID"),
         "verify": MessageLookupByLibrary.simpleMessage("验证"),
         "verifyEmail": MessageLookupByLibrary.simpleMessage("验证电子邮件"),
-        "verifyEmailID": m59,
+        "verifyEmailID": m58,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("验证"),
         "verifyPassword": MessageLookupByLibrary.simpleMessage("验证密码"),
         "verifying": MessageLookupByLibrary.simpleMessage("正在验证..."),
@@ -1075,11 +1072,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "weAreOpenSource": MessageLookupByLibrary.simpleMessage("我们是开源的 ！"),
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage("我们不支持编辑您尚未拥有的照片和相册"),
-        "weHaveSendEmailTo": m60,
+        "weHaveSendEmailTo": m59,
         "weakStrength": MessageLookupByLibrary.simpleMessage("弱"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("欢迎回来！"),
         "yearly": MessageLookupByLibrary.simpleMessage("每年"),
-        "yearsAgo": m61,
+        "yearsAgo": m60,
         "yes": MessageLookupByLibrary.simpleMessage("是"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("是的，取消"),
         "yesConvertToViewer": MessageLookupByLibrary.simpleMessage("是的，转换为查看者"),
@@ -1105,7 +1102,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("莫开玩笑，您不能与自己分享"),
         "youDontHaveAnyArchivedItems":
             MessageLookupByLibrary.simpleMessage("您没有任何存档的项目。"),
-        "youHaveSuccessfullyFreedUp": m62,
+        "youHaveSuccessfullyFreedUp": m61,
         "yourAccountHasBeenDeleted":
             MessageLookupByLibrary.simpleMessage("您的账户已删除"),
         "yourPlanWasSuccessfullyDowngraded":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -5047,16 +5047,6 @@ class S {
     );
   }
 
-  /// `{count} selected`
-  String itemSelectedCount(int count) {
-    return Intl.message(
-      '$count selected',
-      name: 'itemSelectedCount',
-      desc: 'Text to indicate number of items selected',
-      args: [count],
-    );
-  }
-
   /// `Share`
   String get share {
     return Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -695,16 +695,6 @@
   "addToAlbum": "Zum Album hinzufügen",
   "delete": "Löschen",
   "hide": "Ausblenden",
-  "itemSelectedCount": "{count} ausgewählt",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "Teilen",
   "unhideToAlbum": "Im Album anzeigen",
   "restoreToAlbum": "Album wiederherstellen",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -719,16 +719,6 @@
   "addToAlbum": "Add to album",
   "delete": "Delete",
   "hide": "Hide",
-  "itemSelectedCount": "{count} selected",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "Share",
   "unhideToAlbum": "Unhide to album",
   "restoreToAlbum": "Restore to album",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -690,16 +690,6 @@
   "addToAlbum": "Añadir al álbum",
   "delete": "Eliminar",
   "hide": "Ocultar",
-  "itemSelectedCount": "{count} seleccionados",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "Compartir",
   "unhideToAlbum": "Hacer visible al álbum",
   "restoreToAlbum": "Restaurar al álbum",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -598,16 +598,6 @@
   "addToAlbum": "Ajouter à l'album",
   "delete": "Supprimer",
   "hide": "Masquer",
-  "itemSelectedCount": "{count} sélectionné",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "Partager",
   "unhideToAlbum": "Afficher dans l'album",
   "restoreToAlbum": "Restaurer vers l'album",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -716,16 +716,6 @@
   "addToAlbum": "Aggiungi all'album",
   "delete": "Cancella",
   "hide": "Nascondi",
-  "itemSelectedCount": "{count} selezionati",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "Condividi",
   "unhideToAlbum": "Non nascondere l'album",
   "restoreToAlbum": "Ripristina l'album",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -695,16 +695,6 @@
   "addToAlbum": "Toevoegen aan album",
   "delete": "Verwijderen",
   "hide": "Verbergen",
-  "itemSelectedCount": "{count} geselecteerd",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "Delen",
   "unhideToAlbum": "Zichtbaar maken in album",
   "restoreToAlbum": "Terugzetten naar album",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -694,16 +694,6 @@
   "addToAlbum": "添加到相册",
   "delete": "删除",
   "hide": "隐藏",
-  "itemSelectedCount": "已选择 {count} 个",
-  "@itemSelectedCount": {
-    "description": "Text to indicate number of items selected",
-    "placeholders": {
-      "count": {
-        "example": "1|2|3",
-        "type": "int"
-      }
-    }
-  },
   "share": "分享",
   "unhideToAlbum": "取消隐藏到相册",
   "restoreToAlbum": "恢复到相册",

--- a/lib/ui/components/bottom_action_bar/action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/action_bar_widget.dart
@@ -40,42 +40,48 @@ class _ActionBarWidgetState extends State<ActionBarWidget> {
   @override
   Widget build(BuildContext context) {
     final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
     return SizedBox(
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 16, 20, 64),
+        padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            ValueListenableBuilder(
-              valueListenable: _selectedFilesNotifier,
-              builder: (context, value, child) {
-                return Text(
-                  _selectedOwnedFilesNotifier.value !=
-                          _selectedFilesNotifier.value
-                      ? S.of(context).selectedPhotosWithYours(
-                            _selectedFilesNotifier.value,
-                            _selectedOwnedFilesNotifier.value,
-                          )
-                      : S.of(context).selectedPhotos(
-                            _selectedFilesNotifier.value,
-                          ),
-                  style: textTheme.body.copyWith(
-                    color: colorScheme.blurTextBase,
-                  ),
-                );
-              },
+            Flexible(
+              flex: 1,
+              child: ValueListenableBuilder(
+                valueListenable: _selectedFilesNotifier,
+                builder: (context, value, child) {
+                  return Text(
+                    _selectedOwnedFilesNotifier.value !=
+                            _selectedFilesNotifier.value
+                        ? S.of(context).selectedPhotosWithYours(
+                              _selectedFilesNotifier.value,
+                              _selectedOwnedFilesNotifier.value,
+                            )
+                        : S.of(context).selectedPhotos(
+                              _selectedFilesNotifier.value,
+                            ),
+                    style: textTheme.miniMuted,
+                  );
+                },
+              ),
             ),
-            GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () {
-                widget.onCancel?.call();
-              },
-              child: Center(
-                child: Text(
-                  S.of(context).cancel,
-                  style: textTheme.bodyBold
-                      .copyWith(color: colorScheme.blurTextBase),
+            Flexible(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () {
+                    widget.onCancel?.call();
+                  },
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Text(
+                      S.of(context).cancel,
+                      style: textTheme.mini,
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/lib/ui/components/bottom_action_bar/action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/action_bar_widget.dart
@@ -1,23 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:photos/core/configuration.dart';
 import "package:photos/generated/l10n.dart";
-import 'package:photos/models/gallery_type.dart';
 import 'package:photos/models/selected_files.dart';
 import 'package:photos/theme/ente_theme.dart';
 
 class ActionBarWidget extends StatefulWidget {
-  final String? text;
-  final List<Widget> iconButtons;
   final SelectedFiles? selectedFiles;
-  final GalleryType galleryType;
-  final bool isCollaborator;
+  final VoidCallback? onCancel;
 
   const ActionBarWidget({
-    required this.iconButtons,
-    required this.galleryType,
-    this.text,
+    required this.onCancel,
     this.selectedFiles,
-    this.isCollaborator = false,
     super.key,
   });
 
@@ -38,83 +31,58 @@ class _ActionBarWidgetState extends State<ActionBarWidget> {
 
   @override
   void dispose() {
+    _selectedFilesNotifier.dispose();
+    _selectedOwnedFilesNotifier.dispose();
     widget.selectedFiles?.removeListener(_selectedFilesListener);
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: _actionBarWidgets(context),
-      ),
-    );
-  }
-
-  List<Widget> _actionBarWidgets(BuildContext context) {
-    final actionBarWidgets = <Widget>[];
-    final initialLength = widget.iconButtons.length;
     final textTheme = getEnteTextTheme(context);
     final colorScheme = getEnteColorScheme(context);
-
-    actionBarWidgets.addAll(widget.iconButtons);
-    if (widget.text != null) {
-      //adds 12 px spacing at the start and between iconButton elements
-      for (var i = 0; i < initialLength; i++) {
-        actionBarWidgets.insert(
-          2 * i,
-          const SizedBox(
-            width: 12,
-          ),
-        );
-      }
-      actionBarWidgets.insertAll(0, [
-        const SizedBox(width: 20),
-        Flexible(
-          child: Row(
-            children: [
-              widget.selectedFiles != null
-                  ? ValueListenableBuilder(
-                      valueListenable: _selectedFilesNotifier,
-                      builder: (context, value, child) {
-                        return Text(
-                          _selectedOwnedFilesNotifier.value !=
-                                  _selectedFilesNotifier.value
-                              ? S.of(context).selectedPhotosWithYours(
-                                    _selectedFilesNotifier.value,
-                                    _selectedOwnedFilesNotifier.value,
-                                  )
-                              : S.of(context).selectedPhotos(
-                                    _selectedFilesNotifier.value,
-                                  ),
-                          style: textTheme.body.copyWith(
-                            color: colorScheme.blurTextBase,
+    return SizedBox(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 64),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            ValueListenableBuilder(
+              valueListenable: _selectedFilesNotifier,
+              builder: (context, value, child) {
+                return Text(
+                  _selectedOwnedFilesNotifier.value !=
+                          _selectedFilesNotifier.value
+                      ? S.of(context).selectedPhotosWithYours(
+                            _selectedFilesNotifier.value,
+                            _selectedOwnedFilesNotifier.value,
+                          )
+                      : S.of(context).selectedPhotos(
+                            _selectedFilesNotifier.value,
                           ),
-                        );
-                      },
-                    )
-                  : Text(
-                      widget.text!,
-                      style:
-                          textTheme.body.copyWith(color: colorScheme.textMuted),
-                    ),
-            ],
-          ),
+                  style: textTheme.body.copyWith(
+                    color: colorScheme.blurTextBase,
+                  ),
+                );
+              },
+            ),
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () {
+                widget.onCancel?.call();
+              },
+              child: Center(
+                child: Text(
+                  S.of(context).cancel,
+                  style: textTheme.bodyBold
+                      .copyWith(color: colorScheme.blurTextBase),
+                ),
+              ),
+            ),
+          ],
         ),
-      ]);
-      //to add whitespace of 8pts or 12 pts at the end
-      if (widget.iconButtons.length > 1) {
-        actionBarWidgets.add(
-          const SizedBox(width: 8),
-        );
-      } else {
-        actionBarWidgets.add(
-          const SizedBox(width: 12),
-        );
-      }
-    }
-    return actionBarWidgets;
+      ),
+    );
   }
 
   void _selectedFilesListener() {

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -10,12 +10,10 @@ class BottomActionBarWidget extends StatelessWidget {
   final Widget expandedMenu;
   final SelectedFiles? selectedFiles;
   final VoidCallback? onCancel;
-  final bool hasSmallerBottomPadding;
   final Color? backgroundColor;
 
   const BottomActionBarWidget({
     required this.expandedMenu,
-    required this.hasSmallerBottomPadding,
     this.selectedFiles,
     this.onCancel,
     this.backgroundColor,
@@ -24,7 +22,7 @@ class BottomActionBarWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print("HasSmallerBottomPadding: $hasSmallerBottomPadding");
+    final bottomPadding = MediaQuery.of(context).padding.bottom;
     final widthOfScreen = MediaQuery.of(context).size.width;
     final colorScheme = getEnteColorScheme(context);
     final double leftRightPadding = widthOfScreen > restrictedMaxWidth
@@ -41,7 +39,7 @@ class BottomActionBarWidget extends StatelessWidget {
       ),
       padding: EdgeInsets.only(
         top: 4,
-        bottom: hasSmallerBottomPadding ? 0 : 12,
+        bottom: bottomPadding,
         right: leftRightPadding,
         left: leftRightPadding,
       ),

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -90,7 +90,7 @@ class BottomActionBarWidget extends StatelessWidget {
   }
 }
 
-class SelectionOptionButton extends StatelessWidget {
+class SelectionOptionButton extends StatefulWidget {
   final String name;
   final IconData icon;
   const SelectionOptionButton({
@@ -100,27 +100,57 @@ class SelectionOptionButton extends StatelessWidget {
   });
 
   @override
+  State<SelectionOptionButton> createState() => _SelectionOptionButtonState();
+}
+
+class _SelectionOptionButtonState extends State<SelectionOptionButton> {
+  Color? backgroundColor;
+  @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-      child: SizedBox(
-        width: 64,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              icon,
-              size: 24,
-              color: getEnteColorScheme(context).textMuted,
+    final colorScheme = getEnteColorScheme(context);
+    return GestureDetector(
+      onTapDown: (details) {
+        setState(() {
+          backgroundColor = colorScheme.fillFaintPressed;
+        });
+      },
+      onTapUp: (details) {
+        setState(() {
+          backgroundColor = null;
+        });
+      },
+      onTapCancel: () {
+        setState(() {
+          backgroundColor = null;
+        });
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          color: backgroundColor,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+          child: SizedBox(
+            width: 64,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  widget.icon,
+                  size: 24,
+                  color: getEnteColorScheme(context).textMuted,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  widget.name,
+                  textAlign: TextAlign.center,
+                  style: getEnteTextTheme(context).miniMuted,
+                ),
+              ],
             ),
-            const SizedBox(height: 4),
-            Text(
-              name,
-              textAlign: TextAlign.center,
-              style: getEnteTextTheme(context).miniMuted,
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -7,13 +7,13 @@ import 'package:photos/ui/components/bottom_action_bar/action_bar_widget.dart';
 import "package:photos/ui/components/divider_widget.dart";
 
 class BottomActionBarWidget extends StatelessWidget {
-  final Widget expandedMenu;
+  final Widget fileSelectionActionsWidget;
   final SelectedFiles? selectedFiles;
   final VoidCallback? onCancel;
   final Color? backgroundColor;
 
   const BottomActionBarWidget({
-    required this.expandedMenu,
+    required this.fileSelectionActionsWidget,
     this.selectedFiles,
     this.onCancel,
     this.backgroundColor,
@@ -47,38 +47,7 @@ class BottomActionBarWidget extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(height: 12),
-          SingleChildScrollView(
-            physics: const BouncingScrollPhysics(),
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                SizedBox(width: 8),
-                SelectionOptionButton(
-                  name: "Share link",
-                  icon: Icons.link_outlined,
-                ),
-                SelectionOptionButton(name: "Add to album", icon: Icons.add),
-                SelectionOptionButton(
-                  name: "Delete",
-                  icon: Icons.delete_outline,
-                ),
-                SelectionOptionButton(
-                  name: "Hide",
-                  icon: Icons.visibility_off_outlined,
-                ),
-                SelectionOptionButton(
-                  name: "Archive",
-                  icon: Icons.archive_outlined,
-                ),
-                SelectionOptionButton(
-                  name: "Favorite",
-                  icon: Icons.favorite_border_outlined,
-                ),
-                SizedBox(width: 8),
-              ],
-            ),
-          ),
+          fileSelectionActionsWidget,
           const SizedBox(height: 20),
           const DividerWidget(dividerType: DividerType.bottomBar),
           ActionBarWidget(
@@ -93,11 +62,14 @@ class BottomActionBarWidget extends StatelessWidget {
 }
 
 class SelectionOptionButton extends StatefulWidget {
-  final String name;
+  final String labelText;
   final IconData icon;
+  final VoidCallback? onTap;
+
   const SelectionOptionButton({
-    required this.name,
+    required this.labelText,
     required this.icon,
+    required this.onTap,
     super.key,
   });
 
@@ -111,6 +83,7 @@ class _SelectionOptionButtonState extends State<SelectionOptionButton> {
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
     return GestureDetector(
+      onTap: widget.onTap,
       onTapDown: (details) {
         setState(() {
           backgroundColor = colorScheme.fillFaintPressed;
@@ -146,7 +119,7 @@ class _SelectionOptionButtonState extends State<SelectionOptionButton> {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  widget.name,
+                  widget.labelText,
                   textAlign: TextAlign.center,
                   style: getEnteTextTheme(context).miniMuted,
                 ),

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -1,20 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:photos/core/constants.dart';
+import "package:photos/models/collection.dart";
+import "package:photos/models/gallery_type.dart";
 import 'package:photos/models/selected_files.dart';
 import "package:photos/theme/effects.dart";
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/bottom_action_bar/action_bar_widget.dart';
 import "package:photos/ui/components/divider_widget.dart";
+import "package:photos/ui/viewer/actions/file_selection_actions_widget.dart";
 
 class BottomActionBarWidget extends StatelessWidget {
-  final Widget fileSelectionActionsWidget;
-  final SelectedFiles? selectedFiles;
+  final GalleryType galleryType;
+  final Collection? collection;
+  final SelectedFiles selectedFiles;
   final VoidCallback? onCancel;
   final Color? backgroundColor;
 
   const BottomActionBarWidget({
-    required this.fileSelectionActionsWidget,
-    this.selectedFiles,
+    required this.galleryType,
+    required this.selectedFiles,
+    this.collection,
     this.onCancel,
     this.backgroundColor,
     super.key,
@@ -47,7 +52,11 @@ class BottomActionBarWidget extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(height: 12),
-          fileSelectionActionsWidget,
+          FileSelectionActionsWidget(
+            galleryType,
+            selectedFiles,
+            collection: collection,
+          ),
           const SizedBox(height: 20),
           const DividerWidget(dividerType: DividerType.bottomBar),
           ActionBarWidget(
@@ -56,77 +65,6 @@ class BottomActionBarWidget extends StatelessWidget {
           ),
           // const SizedBox(height: 2)
         ],
-      ),
-    );
-  }
-}
-
-class SelectionOptionButton extends StatefulWidget {
-  final String labelText;
-  final IconData icon;
-  final VoidCallback? onTap;
-
-  const SelectionOptionButton({
-    required this.labelText,
-    required this.icon,
-    required this.onTap,
-    super.key,
-  });
-
-  @override
-  State<SelectionOptionButton> createState() => _SelectionOptionButtonState();
-}
-
-class _SelectionOptionButtonState extends State<SelectionOptionButton> {
-  Color? backgroundColor;
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    return GestureDetector(
-      onTap: widget.onTap,
-      onTapDown: (details) {
-        setState(() {
-          backgroundColor = colorScheme.fillFaintPressed;
-        });
-      },
-      onTapUp: (details) {
-        setState(() {
-          backgroundColor = null;
-        });
-      },
-      onTapCancel: () {
-        setState(() {
-          backgroundColor = null;
-        });
-      },
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8),
-          color: backgroundColor,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-          child: SizedBox(
-            width: 64,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  widget.icon,
-                  size: 24,
-                  color: getEnteColorScheme(context).textMuted,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  widget.labelText,
-                  textAlign: TextAlign.center,
-                  style: getEnteTextTheme(context).miniMuted,
-                ),
-              ],
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -4,6 +4,7 @@ import 'package:photos/models/selected_files.dart';
 import "package:photos/theme/effects.dart";
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/bottom_action_bar/action_bar_widget.dart';
+import "package:photos/ui/components/divider_widget.dart";
 
 class BottomActionBarWidget extends StatelessWidget {
   final Widget expandedMenu;
@@ -23,6 +24,7 @@ class BottomActionBarWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print("HasSmallerBottomPadding: $hasSmallerBottomPadding");
     final widthOfScreen = MediaQuery.of(context).size.width;
     final colorScheme = getEnteColorScheme(context);
     final double leftRightPadding = widthOfScreen > restrictedMaxWidth
@@ -32,21 +34,96 @@ class BottomActionBarWidget extends StatelessWidget {
       decoration: BoxDecoration(
         color: backgroundColor ?? colorScheme.backgroundElevated2,
         boxShadow: shadowFloatFaintLight,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(8),
+          topRight: Radius.circular(8),
+        ),
       ),
       padding: EdgeInsets.only(
         top: 4,
-        bottom: hasSmallerBottomPadding ? 24 : 36,
+        bottom: hasSmallerBottomPadding ? 0 : 12,
         right: leftRightPadding,
         left: leftRightPadding,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          const SizedBox(height: 12),
+          SingleChildScrollView(
+            physics: const BouncingScrollPhysics(),
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                SelectionOptionButton(
+                  name: "Share link",
+                  icon: Icons.link_outlined,
+                ),
+                SelectionOptionButton(name: "Add to album", icon: Icons.add),
+                SelectionOptionButton(
+                  name: "Delete",
+                  icon: Icons.delete_outline,
+                ),
+                SelectionOptionButton(
+                  name: "Hide",
+                  icon: Icons.visibility_off_outlined,
+                ),
+                SelectionOptionButton(
+                  name: "Archive",
+                  icon: Icons.archive_outlined,
+                ),
+                SelectionOptionButton(
+                  name: "Favorite",
+                  icon: Icons.favorite_border_outlined,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          const DividerWidget(dividerType: DividerType.bottomBar),
           ActionBarWidget(
             selectedFiles: selectedFiles,
             onCancel: onCancel,
           ),
+          // const SizedBox(height: 2)
         ],
+      ),
+    );
+  }
+}
+
+class SelectionOptionButton extends StatelessWidget {
+  final String name;
+  final IconData icon;
+  const SelectionOptionButton({
+    required this.name,
+    required this.icon,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: SizedBox(
+        width: 64,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              size: 24,
+              color: getEnteColorScheme(context).textMuted,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              name,
+              textAlign: TextAlign.center,
+              style: getEnteTextTheme(context).miniMuted,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -3,7 +3,6 @@ import 'package:photos/core/constants.dart';
 import "package:photos/models/collection.dart";
 import "package:photos/models/gallery_type.dart";
 import 'package:photos/models/selected_files.dart';
-import "package:photos/theme/effects.dart";
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/bottom_action_bar/action_bar_widget.dart';
 import "package:photos/ui/components/divider_widget.dart";
@@ -36,7 +35,6 @@ class BottomActionBarWidget extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: backgroundColor ?? colorScheme.backgroundElevated2,
-        boxShadow: shadowFloatFaintLight,
         borderRadius: const BorderRadius.only(
           topLeft: Radius.circular(8),
           topRight: Radius.circular(8),

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -53,6 +53,7 @@ class BottomActionBarWidget extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: const [
+                SizedBox(width: 8),
                 SelectionOptionButton(
                   name: "Share link",
                   icon: Icons.link_outlined,
@@ -74,6 +75,7 @@ class BottomActionBarWidget extends StatelessWidget {
                   name: "Favorite",
                   icon: Icons.favorite_border_outlined,
                 ),
+                SizedBox(width: 8),
               ],
             ),
           ),

--- a/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
+++ b/lib/ui/components/bottom_action_bar/bottom_action_bar_widget.dart
@@ -1,44 +1,30 @@
-import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:photos/core/constants.dart';
-import "package:photos/generated/l10n.dart";
-import 'package:photos/models/gallery_type.dart';
 import 'package:photos/models/selected_files.dart';
 import "package:photos/theme/effects.dart";
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/bottom_action_bar/action_bar_widget.dart';
-import 'package:photos/ui/components/buttons/icon_button_widget.dart';
 
 class BottomActionBarWidget extends StatelessWidget {
-  final String? text;
-  final List<Widget>? iconButtons;
   final Widget expandedMenu;
   final SelectedFiles? selectedFiles;
   final VoidCallback? onCancel;
   final bool hasSmallerBottomPadding;
-  final GalleryType type;
   final Color? backgroundColor;
 
-  BottomActionBarWidget({
+  const BottomActionBarWidget({
     required this.expandedMenu,
     required this.hasSmallerBottomPadding,
-    required this.type,
     this.selectedFiles,
-    this.text,
-    this.iconButtons,
     this.onCancel,
     this.backgroundColor,
     super.key,
   });
 
-  final ExpandableController _expandableController =
-      ExpandableController(initialExpanded: false);
-
   @override
   Widget build(BuildContext context) {
     final widthOfScreen = MediaQuery.of(context).size.width;
     final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
     final double leftRightPadding = widthOfScreen > restrictedMaxWidth
         ? (widthOfScreen - restrictedMaxWidth) / 2
         : 0;
@@ -56,127 +42,12 @@ class BottomActionBarWidget extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          ExpandableNotifier(
-            controller: _expandableController,
-            child: ExpandablePanel(
-              theme: _getExpandableTheme(),
-              header: Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: text == null ? 12 : 0,
-                ),
-                child: ActionBarWidget(
-                  selectedFiles: selectedFiles,
-                  galleryType: type,
-                  text: text,
-                  iconButtons: _iconButtons(context),
-                ),
-              ),
-              expanded: expandedMenu,
-              collapsed: const SizedBox.shrink(),
-              controller: _expandableController,
-            ),
+          ActionBarWidget(
+            selectedFiles: selectedFiles,
+            onCancel: onCancel,
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: 14,
-            ),
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () {
-                onCancel?.call();
-                _expandableController.value = false;
-              },
-              child: Center(
-                child: Text(
-                  S.of(context).cancel,
-                  style: textTheme.bodyBold
-                      .copyWith(color: colorScheme.blurTextBase),
-                ),
-              ),
-            ),
-          )
         ],
       ),
     );
-  }
-
-  List<Widget> _iconButtons(BuildContext context) {
-    final iconButtonsWithExpansionIcon = <Widget>[
-      ...?iconButtons,
-      ExpansionIconWidget(expandableController: _expandableController)
-    ];
-    return iconButtonsWithExpansionIcon;
-  }
-
-  ExpandableThemeData _getExpandableTheme() {
-    return const ExpandableThemeData(
-      hasIcon: false,
-      useInkWell: false,
-      tapBodyToCollapse: false,
-      tapBodyToExpand: false,
-      tapHeaderToExpand: false,
-      animationDuration: Duration(milliseconds: 400),
-      crossFadePoint: 0.5,
-    );
-  }
-}
-
-class ExpansionIconWidget extends StatefulWidget {
-  final ExpandableController expandableController;
-
-  const ExpansionIconWidget({required this.expandableController, super.key});
-
-  @override
-  State<ExpansionIconWidget> createState() => _ExpansionIconWidgetState();
-}
-
-class _ExpansionIconWidgetState extends State<ExpansionIconWidget> {
-  @override
-  void initState() {
-    widget.expandableController.addListener(_expandableListener);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    widget.expandableController.removeListener(_expandableListener);
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final iconColor = getEnteColorScheme(context).blurStrokeBase;
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 200),
-      switchInCurve: Curves.easeInOutExpo,
-      child: widget.expandableController.value
-          ? IconButtonWidget(
-              key: const ValueKey<bool>(false),
-              onTap: () {
-                widget.expandableController.value = false;
-                setState(() {});
-              },
-              icon: Icons.expand_more_outlined,
-              iconButtonType: IconButtonType.primary,
-              iconColor: iconColor,
-            )
-          : IconButtonWidget(
-              key: const ValueKey<bool>(true),
-              onTap: () {
-                widget.expandableController.value = true;
-                setState(() {});
-              },
-              icon: Icons.more_horiz_outlined,
-              iconButtonType: IconButtonType.primary,
-              iconColor: iconColor,
-            ),
-    );
-  }
-
-  _expandableListener() {
-    if (mounted) {
-      setState(() {});
-    }
   }
 }

--- a/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
+++ b/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
@@ -23,20 +23,6 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
   Color? backgroundColor;
 
   @override
-  void initState() {
-    super.initState();
-    // widthOfButton = getWidthOfButton();
-  }
-
-  getWidthOfButton() {
-    final widthOfWidestWord = getWidthOfLongestWord(
-      widget.labelText,
-    );
-    if (widthOfWidestWord > minWidth) return widthOfWidestWord;
-    return minWidth;
-  }
-
-  @override
   Widget build(BuildContext context) {
     widthOfButton = getWidthOfButton();
     final colorScheme = getEnteColorScheme(context);
@@ -90,7 +76,15 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
     );
   }
 
-  double getWidthOfText(String text, TextStyle style) {
+  getWidthOfButton() {
+    final widthOfWidestWord = getWidthOfWidestWord(
+      widget.labelText,
+    );
+    if (widthOfWidestWord > minWidth) return widthOfWidestWord;
+    return minWidth;
+  }
+
+  double computeWidthOfWord(String text, TextStyle style) {
     final textPainter = TextPainter(
       text: TextSpan(text: text, style: style),
       maxLines: 1,
@@ -101,13 +95,14 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
     return textPainter.size.width;
   }
 
-  double getWidthOfLongestWord(String labelText) {
+  double getWidthOfWidestWord(String labelText) {
     final words = labelText.split(RegExp(r'\s+'));
     if (words.isEmpty) return 0.0;
 
     double maxWidth = 0.0;
     for (String word in words) {
-      final width = getWidthOfText(word, getEnteTextTheme(context).miniMuted);
+      final width =
+          computeWidthOfWord(word, getEnteTextTheme(context).miniMuted);
       if (width > maxWidth) {
         maxWidth = width;
       }

--- a/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
+++ b/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
@@ -5,13 +5,11 @@ class SelectionActionButton extends StatefulWidget {
   final String labelText;
   final IconData icon;
   final VoidCallback? onTap;
-  final TextStyle textStyle;
 
   const SelectionActionButton({
     required this.labelText,
     required this.icon,
     required this.onTap,
-    required this.textStyle,
     super.key,
   });
 
@@ -27,13 +25,12 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
   @override
   void initState() {
     super.initState();
-    widthOfButton = getWidthOfButton();
+    // widthOfButton = getWidthOfButton();
   }
 
   getWidthOfButton() {
     final widthOfWidestWord = getWidthOfLongestWord(
       widget.labelText,
-      widget.textStyle,
     );
     if (widthOfWidestWord > minWidth) return widthOfWidestWord;
     return minWidth;
@@ -41,6 +38,7 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
 
   @override
   Widget build(BuildContext context) {
+    widthOfButton = getWidthOfButton();
     final colorScheme = getEnteColorScheme(context);
     return GestureDetector(
       onTap: widget.onTap,
@@ -81,7 +79,8 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
                 Text(
                   widget.labelText,
                   textAlign: TextAlign.center,
-                  style: widget.textStyle,
+                  //textTheme in [getWidthOfLongestWord] should be same as this
+                  style: getEnteTextTheme(context).miniMuted,
                 ),
               ],
             ),
@@ -96,18 +95,19 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
       text: TextSpan(text: text, style: style),
       maxLines: 1,
       textDirection: TextDirection.ltr,
+      textScaleFactor: MediaQuery.of(context).textScaleFactor,
     )..layout();
 
     return textPainter.size.width;
   }
 
-  double getWidthOfLongestWord(String labelText, TextStyle style) {
+  double getWidthOfLongestWord(String labelText) {
     final words = labelText.split(RegExp(r'\s+'));
     if (words.isEmpty) return 0.0;
 
     double maxWidth = 0.0;
     for (String word in words) {
-      final width = getWidthOfText(word, style);
+      final width = getWidthOfText(word, getEnteTextTheme(context).miniMuted);
       if (width > maxWidth) {
         maxWidth = width;
       }

--- a/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
+++ b/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
@@ -5,11 +5,13 @@ class SelectionActionButton extends StatefulWidget {
   final String labelText;
   final IconData icon;
   final VoidCallback? onTap;
+  final TextStyle textStyle;
 
   const SelectionActionButton({
     required this.labelText,
     required this.icon,
     required this.onTap,
+    required this.textStyle,
     super.key,
   });
 
@@ -18,7 +20,25 @@ class SelectionActionButton extends StatefulWidget {
 }
 
 class _SelectionActionButtonState extends State<SelectionActionButton> {
+  static const minWidth = 64.0;
+  late double widthOfButton;
   Color? backgroundColor;
+
+  @override
+  void initState() {
+    super.initState();
+    widthOfButton = getWidthOfButton();
+  }
+
+  getWidthOfButton() {
+    final widthOfWidestWord = getWidthOfLongestWord(
+      widget.labelText,
+      widget.textStyle,
+    );
+    if (widthOfWidestWord > minWidth) return widthOfWidestWord;
+    return minWidth;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
@@ -47,7 +67,7 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
           child: SizedBox(
-            width: 64,
+            width: widthOfButton,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
@@ -61,7 +81,7 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
                 Text(
                   widget.labelText,
                   textAlign: TextAlign.center,
-                  style: getEnteTextTheme(context).miniMuted,
+                  style: widget.textStyle,
                 ),
               ],
             ),
@@ -69,5 +89,29 @@ class _SelectionActionButtonState extends State<SelectionActionButton> {
         ),
       ),
     );
+  }
+
+  double getWidthOfText(String text, TextStyle style) {
+    final textPainter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      maxLines: 1,
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    return textPainter.size.width;
+  }
+
+  double getWidthOfLongestWord(String labelText, TextStyle style) {
+    final words = labelText.split(RegExp(r'\s+'));
+    if (words.isEmpty) return 0.0;
+
+    double maxWidth = 0.0;
+    for (String word in words) {
+      final width = getWidthOfText(word, style);
+      if (width > maxWidth) {
+        maxWidth = width;
+      }
+    }
+    return maxWidth;
   }
 }

--- a/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
+++ b/lib/ui/components/bottom_action_bar/selection_action_button_widget.dart
@@ -1,0 +1,73 @@
+import "package:flutter/material.dart";
+import "package:photos/theme/ente_theme.dart";
+
+class SelectionActionButton extends StatefulWidget {
+  final String labelText;
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  const SelectionActionButton({
+    required this.labelText,
+    required this.icon,
+    required this.onTap,
+    super.key,
+  });
+
+  @override
+  State<SelectionActionButton> createState() => _SelectionActionButtonState();
+}
+
+class _SelectionActionButtonState extends State<SelectionActionButton> {
+  Color? backgroundColor;
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = getEnteColorScheme(context);
+    return GestureDetector(
+      onTap: widget.onTap,
+      onTapDown: (details) {
+        setState(() {
+          backgroundColor = colorScheme.fillFaintPressed;
+        });
+      },
+      onTapUp: (details) {
+        setState(() {
+          backgroundColor = null;
+        });
+      },
+      onTapCancel: () {
+        setState(() {
+          backgroundColor = null;
+        });
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          color: backgroundColor,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+          child: SizedBox(
+            width: 64,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  widget.icon,
+                  size: 24,
+                  color: getEnteColorScheme(context).textMuted,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  widget.labelText,
+                  textAlign: TextAlign.center,
+                  style: getEnteTextTheme(context).miniMuted,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/tabs/home_widget.dart
+++ b/lib/ui/tabs/home_widget.dart
@@ -36,7 +36,6 @@ import 'package:photos/states/user_details_state.dart';
 import 'package:photos/theme/colors.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/collections/collection_action_sheet.dart';
-import "package:photos/ui/common/bottom_shadow.dart";
 import 'package:photos/ui/extents_page_view.dart';
 import 'package:photos/ui/home/grant_permissions_widget.dart';
 import 'package:photos/ui/home/header_widget.dart';
@@ -404,12 +403,6 @@ class _HomeWidgetState extends State<HomeWidget> {
               ],
             );
           },
-        ),
-        const Align(
-          alignment: Alignment.bottomCenter,
-          child: BottomShadowWidget(
-            offsetDy: 36,
-          ),
         ),
         Align(
           alignment: Alignment.bottomCenter,

--- a/lib/ui/tabs/user_collections_tab.dart
+++ b/lib/ui/tabs/user_collections_tab.dart
@@ -188,7 +188,9 @@ class _UserCollectionsTabState extends State<UserCollectionsTab>
             ),
           ),
         ),
-        const SliverToBoxAdapter(child: SizedBox(height: 48)),
+        SliverToBoxAdapter(
+          child: SizedBox(height: 64 + MediaQuery.of(context).padding.bottom),
+        ),
       ],
     );
   }

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -17,7 +17,7 @@ import 'package:photos/ui/actions/collection/collection_file_actions.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/collections/collection_action_sheet.dart';
 import 'package:photos/ui/components/action_sheet_widget.dart';
-import "package:photos/ui/components/bottom_action_bar/bottom_action_bar_widget.dart";
+import "package:photos/ui/components/bottom_action_bar/selection_action_button_widget.dart";
 import 'package:photos/ui/components/buttons/button_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/sharing/manage_links_widget.dart';
@@ -109,12 +109,12 @@ class _FileSelectionActionsWidgetState
     final bool anyUploadedFiles = split.ownedByCurrentUser.isNotEmpty;
     final bool showRemoveOption = widget.type.showRemoveFromAlbum();
     debugPrint('$runtimeType building  $mounted');
-    final List<SelectionOptionButton> items = [];
+    final List<SelectionActionButton> items = [];
 
     if (widget.type.showCreateLink()) {
       if (_cachedCollectionForSharedLink != null && anyUploadedFiles) {
         items.add(
-          SelectionOptionButton(
+          SelectionActionButton(
             icon: Icons.copy_outlined,
             labelText: S.of(context).copyLink,
             onTap: anyUploadedFiles ? _copyLink : null,
@@ -122,7 +122,7 @@ class _FileSelectionActionsWidgetState
         );
       } else {
         items.add(
-          SelectionOptionButton(
+          SelectionActionButton(
             icon: Icons.link_outlined,
             labelText: S.of(context).shareLink + suffix,
             onTap: anyUploadedFiles ? _onCreatedSharedLinkClicked : null,
@@ -144,7 +144,7 @@ class _FileSelectionActionsWidgetState
         widget.selectedFiles.files.length <=
             CollageCreatorPage.collageItemsMax) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.grid_view_outlined,
           labelText: S.of(context).createCollage,
           onTap: _onCreateCollageClicked,
@@ -156,7 +156,7 @@ class _FileSelectionActionsWidgetState
         split.ownedByCurrentUser.isEmpty;
     if (widget.type.showAddToAlbum()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon:
               showUploadIcon ? Icons.cloud_upload_outlined : Icons.add_outlined,
           labelText: showUploadIcon
@@ -168,7 +168,7 @@ class _FileSelectionActionsWidgetState
     }
     if (widget.type.showMoveToAlbum()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.arrow_forward_outlined,
           labelText: S.of(context).moveToAlbum + suffix,
           onTap: anyUploadedFiles ? _moveFiles : null,
@@ -178,7 +178,7 @@ class _FileSelectionActionsWidgetState
 
     if (showRemoveOption) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.remove_outlined,
           labelText: "${S.of(context).removeFromAlbum}$removeSuffix",
           onTap: removeCount > 0 ? _removeFilesFromAlbum : null,
@@ -188,7 +188,7 @@ class _FileSelectionActionsWidgetState
 
     if (widget.type.showDeleteOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.delete_outline,
           labelText: S.of(context).delete + suffixInPending,
           onTap: anyOwnedFiles ? _onDeleteClick : null,
@@ -198,7 +198,7 @@ class _FileSelectionActionsWidgetState
 
     if (widget.type.showHideOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.visibility_off_outlined,
           labelText: S.of(context).hide + suffix,
           onTap: anyUploadedFiles ? _onHideClick : null,
@@ -206,7 +206,7 @@ class _FileSelectionActionsWidgetState
       );
     } else if (widget.type.showUnHideOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.visibility_off_outlined,
           labelText: S.of(context).unhide + suffix,
           onTap: _onUnhideClick,
@@ -215,7 +215,7 @@ class _FileSelectionActionsWidgetState
     }
     if (widget.type.showArchiveOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.archive_outlined,
           labelText: S.of(context).archive + suffix,
           onTap: anyUploadedFiles ? _onArchiveClick : null,
@@ -223,7 +223,7 @@ class _FileSelectionActionsWidgetState
       );
     } else if (widget.type.showUnArchiveOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.unarchive,
           labelText: S.of(context).unarchive + suffix,
           onTap: _onUnArchiveClick,
@@ -233,7 +233,7 @@ class _FileSelectionActionsWidgetState
 
     if (widget.type.showFavoriteOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.favorite_border_rounded,
           labelText: S.of(context).favorite + suffix,
           onTap: anyUploadedFiles ? _onFavoriteClick : null,
@@ -241,7 +241,7 @@ class _FileSelectionActionsWidgetState
       );
     } else if (widget.type.showUnFavoriteOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.favorite,
           labelText: S.of(context).removeFromFavorite + suffix,
           onTap: _onUnFavoriteClick,
@@ -251,7 +251,7 @@ class _FileSelectionActionsWidgetState
 
     if (widget.type.showRestoreOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.restore_outlined,
           labelText: S.of(context).restore,
           onTap: _restore,
@@ -261,7 +261,7 @@ class _FileSelectionActionsWidgetState
 
     if (widget.type.showPermanentlyDeleteOption()) {
       items.add(
-        SelectionOptionButton(
+        SelectionActionButton(
           icon: Icons.delete_forever_outlined,
           labelText: S.of(context).permanentlyDelete,
           onTap: _permanentlyDelete,

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -25,6 +25,7 @@ import "package:photos/ui/tools/collage/collage_creator_page.dart";
 import 'package:photos/utils/delete_file_util.dart';
 import 'package:photos/utils/magic_util.dart';
 import 'package:photos/utils/navigation_util.dart';
+import "package:photos/utils/share_util.dart";
 import 'package:photos/utils/toast_util.dart';
 
 class FileSelectionActionsWidget extends StatefulWidget {
@@ -57,6 +58,7 @@ class _FileSelectionActionsWidgetState
   // links if user keeps on creating Create link button after selecting
   // few files. This link is reset on any selection changed;
   Collection? _cachedCollectionForSharedLink;
+  final GlobalKey shareButtonKey = GlobalKey();
 
   @override
   void initState() {
@@ -268,6 +270,18 @@ class _FileSelectionActionsWidgetState
         ),
       );
     }
+
+    items.add(
+      SelectionActionButton(
+        labelText: "Share",
+        icon: Icons.adaptive.share_outlined,
+        onTap: () => shareSelected(
+          context,
+          shareButtonKey,
+          widget.selectedFiles.files.toList(),
+        ),
+      ),
+    );
 
     if (items.isNotEmpty) {
       return SingleChildScrollView(

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -13,13 +13,11 @@ import "package:photos/models/metadata/common_keys.dart";
 import 'package:photos/models/selected_files.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/hidden_service.dart';
-import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/actions/collection/collection_file_actions.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/collections/collection_action_sheet.dart';
 import 'package:photos/ui/components/action_sheet_widget.dart';
-import 'package:photos/ui/components/blur_menu_item_widget.dart';
-import 'package:photos/ui/components/bottom_action_bar/expanded_menu_widget.dart';
+import "package:photos/ui/components/bottom_action_bar/bottom_action_bar_widget.dart";
 import 'package:photos/ui/components/buttons/button_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/sharing/manage_links_widget.dart';
@@ -29,13 +27,13 @@ import 'package:photos/utils/magic_util.dart';
 import 'package:photos/utils/navigation_util.dart';
 import 'package:photos/utils/toast_util.dart';
 
-class FileSelectionActionWidget extends StatefulWidget {
+class FileSelectionActionsWidget extends StatefulWidget {
   final GalleryType type;
   final Collection? collection;
   final DeviceCollection? deviceCollection;
   final SelectedFiles selectedFiles;
 
-  const FileSelectionActionWidget(
+  const FileSelectionActionsWidget(
     this.type,
     this.selectedFiles, {
     Key? key,
@@ -44,11 +42,12 @@ class FileSelectionActionWidget extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<FileSelectionActionWidget> createState() =>
-      _FileSelectionActionWidgetState();
+  State<FileSelectionActionsWidget> createState() =>
+      _FileSelectionActionsWidgetState();
 }
 
-class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
+class _FileSelectionActionsWidgetState
+    extends State<FileSelectionActionsWidget> {
   late int currentUserID;
   late FilesSplit split;
   late CollectionActions collectionActions;
@@ -110,27 +109,22 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
     final bool anyUploadedFiles = split.ownedByCurrentUser.isNotEmpty;
     final bool showRemoveOption = widget.type.showRemoveFromAlbum();
     debugPrint('$runtimeType building  $mounted');
-    final colorScheme = getEnteColorScheme(context);
-    final List<List<BlurMenuItemWidget>> items = [];
-    final List<BlurMenuItemWidget> firstList = [];
-    final List<BlurMenuItemWidget> secondList = [];
+    final List<SelectionOptionButton> items = [];
 
     if (widget.type.showCreateLink()) {
       if (_cachedCollectionForSharedLink != null && anyUploadedFiles) {
-        firstList.add(
-          BlurMenuItemWidget(
-            leadingIcon: Icons.copy_outlined,
+        items.add(
+          SelectionOptionButton(
+            icon: Icons.copy_outlined,
             labelText: S.of(context).copyLink,
-            menuItemColor: colorScheme.fillFaint,
             onTap: anyUploadedFiles ? _copyLink : null,
           ),
         );
       } else {
-        firstList.add(
-          BlurMenuItemWidget(
-            leadingIcon: Icons.link_outlined,
+        items.add(
+          SelectionOptionButton(
+            icon: Icons.link_outlined,
             labelText: S.of(context).shareLink + suffix,
-            menuItemColor: colorScheme.fillFaint,
             onTap: anyUploadedFiles ? _onCreatedSharedLinkClicked : null,
           ),
         );
@@ -149,11 +143,10 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
             CollageCreatorPage.collageItemsMin &&
         widget.selectedFiles.files.length <=
             CollageCreatorPage.collageItemsMax) {
-      firstList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.grid_view_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.grid_view_outlined,
           labelText: S.of(context).createCollage,
-          menuItemColor: colorScheme.fillFaint,
           onTap: _onCreateCollageClicked,
         ),
       );
@@ -162,139 +155,132 @@ class _FileSelectionActionWidgetState extends State<FileSelectionActionWidget> {
     final showUploadIcon = widget.type == GalleryType.localFolder &&
         split.ownedByCurrentUser.isEmpty;
     if (widget.type.showAddToAlbum()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon:
+      items.add(
+        SelectionOptionButton(
+          icon:
               showUploadIcon ? Icons.cloud_upload_outlined : Icons.add_outlined,
           labelText: showUploadIcon
               ? S.of(context).addToEnte
               : S.of(context).addToAlbum + suffixInPending,
-          menuItemColor: colorScheme.fillFaint,
           onTap: anyOwnedFiles ? _addToAlbum : null,
         ),
       );
     }
     if (widget.type.showMoveToAlbum()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.arrow_forward_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.arrow_forward_outlined,
           labelText: S.of(context).moveToAlbum + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: anyUploadedFiles ? _moveFiles : null,
         ),
       );
     }
 
     if (showRemoveOption) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.remove_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.remove_outlined,
           labelText: "${S.of(context).removeFromAlbum}$removeSuffix",
-          menuItemColor: colorScheme.fillFaint,
           onTap: removeCount > 0 ? _removeFilesFromAlbum : null,
         ),
       );
     }
 
     if (widget.type.showDeleteOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.delete_outline,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.delete_outline,
           labelText: S.of(context).delete + suffixInPending,
-          menuItemColor: colorScheme.fillFaint,
           onTap: anyOwnedFiles ? _onDeleteClick : null,
         ),
       );
     }
 
     if (widget.type.showHideOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.visibility_off_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.visibility_off_outlined,
           labelText: S.of(context).hide + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: anyUploadedFiles ? _onHideClick : null,
         ),
       );
     } else if (widget.type.showUnHideOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.visibility_off_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.visibility_off_outlined,
           labelText: S.of(context).unhide + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: _onUnhideClick,
         ),
       );
     }
     if (widget.type.showArchiveOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.archive_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.archive_outlined,
           labelText: S.of(context).archive + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: anyUploadedFiles ? _onArchiveClick : null,
         ),
       );
     } else if (widget.type.showUnArchiveOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.unarchive,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.unarchive,
           labelText: S.of(context).unarchive + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: _onUnArchiveClick,
         ),
       );
     }
 
     if (widget.type.showFavoriteOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.favorite_border_rounded,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.favorite_border_rounded,
           labelText: S.of(context).favorite + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: anyUploadedFiles ? _onFavoriteClick : null,
         ),
       );
     } else if (widget.type.showUnFavoriteOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.favorite,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.favorite,
           labelText: S.of(context).removeFromFavorite + suffix,
-          menuItemColor: colorScheme.fillFaint,
           onTap: _onUnFavoriteClick,
         ),
       );
     }
 
     if (widget.type.showRestoreOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.restore_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.restore_outlined,
           labelText: S.of(context).restore,
-          menuItemColor: colorScheme.fillFaint,
           onTap: _restore,
         ),
       );
     }
 
     if (widget.type.showPermanentlyDeleteOption()) {
-      secondList.add(
-        BlurMenuItemWidget(
-          leadingIcon: Icons.delete_forever_outlined,
+      items.add(
+        SelectionOptionButton(
+          icon: Icons.delete_forever_outlined,
           labelText: S.of(context).permanentlyDelete,
-          menuItemColor: colorScheme.fillFaint,
           onTap: _permanentlyDelete,
         ),
       );
     }
 
-    if (firstList.isNotEmpty || secondList.isNotEmpty) {
-      if (firstList.isNotEmpty) {
-        items.add(firstList);
-      }
-      items.add(secondList);
-      return ExpandedMenuWidget(
-        items: items,
+    if (items.isNotEmpty) {
+      return SingleChildScrollView(
+        physics: const BouncingScrollPhysics(),
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(width: 8),
+            ...items,
+            const SizedBox(width: 8),
+          ],
+        ),
       );
     } else {
       // TODO: Return "Select All" here

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -13,7 +13,6 @@ import "package:photos/models/metadata/common_keys.dart";
 import 'package:photos/models/selected_files.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/hidden_service.dart';
-import "package:photos/theme/ente_theme.dart";
 import 'package:photos/ui/actions/collection/collection_file_actions.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/collections/collection_action_sheet.dart';
@@ -88,7 +87,6 @@ class _FileSelectionActionsWidgetState
 
   @override
   Widget build(BuildContext context) {
-    final labelTextStyle = getEnteTextTheme(context).miniMuted;
     final bool showPrefix =
         split.pendingUploads.isNotEmpty || split.ownedByOtherUsers.isNotEmpty;
     final String suffix = showPrefix
@@ -120,7 +118,6 @@ class _FileSelectionActionsWidgetState
             icon: Icons.copy_outlined,
             labelText: S.of(context).copyLink,
             onTap: anyUploadedFiles ? _copyLink : null,
-            textStyle: labelTextStyle,
           ),
         );
       } else {
@@ -129,7 +126,6 @@ class _FileSelectionActionsWidgetState
             icon: Icons.link_outlined,
             labelText: S.of(context).shareLink + suffix,
             onTap: anyUploadedFiles ? _onCreatedSharedLinkClicked : null,
-            textStyle: labelTextStyle,
           ),
         );
       }
@@ -152,7 +148,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.grid_view_outlined,
           labelText: S.of(context).createCollage,
           onTap: _onCreateCollageClicked,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -168,7 +163,6 @@ class _FileSelectionActionsWidgetState
               ? S.of(context).addToEnte
               : S.of(context).addToAlbum + suffixInPending,
           onTap: anyOwnedFiles ? _addToAlbum : null,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -178,7 +172,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.arrow_forward_outlined,
           labelText: S.of(context).moveToAlbum + suffix,
           onTap: anyUploadedFiles ? _moveFiles : null,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -189,7 +182,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.remove_outlined,
           labelText: "${S.of(context).removeFromAlbum}$removeSuffix",
           onTap: removeCount > 0 ? _removeFilesFromAlbum : null,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -200,7 +192,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.delete_outline,
           labelText: S.of(context).delete + suffixInPending,
           onTap: anyOwnedFiles ? _onDeleteClick : null,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -211,7 +202,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.visibility_off_outlined,
           labelText: S.of(context).hide + suffix,
           onTap: anyUploadedFiles ? _onHideClick : null,
-          textStyle: labelTextStyle,
         ),
       );
     } else if (widget.type.showUnHideOption()) {
@@ -220,7 +210,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.visibility_off_outlined,
           labelText: S.of(context).unhide + suffix,
           onTap: _onUnhideClick,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -230,7 +219,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.archive_outlined,
           labelText: S.of(context).archive + suffix,
           onTap: anyUploadedFiles ? _onArchiveClick : null,
-          textStyle: labelTextStyle,
         ),
       );
     } else if (widget.type.showUnArchiveOption()) {
@@ -239,7 +227,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.unarchive,
           labelText: S.of(context).unarchive + suffix,
           onTap: _onUnArchiveClick,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -250,7 +237,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.favorite_border_rounded,
           labelText: S.of(context).favorite + suffix,
           onTap: anyUploadedFiles ? _onFavoriteClick : null,
-          textStyle: labelTextStyle,
         ),
       );
     } else if (widget.type.showUnFavoriteOption()) {
@@ -259,7 +245,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.favorite,
           labelText: S.of(context).removeFromFavorite + suffix,
           onTap: _onUnFavoriteClick,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -270,7 +255,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.restore_outlined,
           labelText: S.of(context).restore,
           onTap: _restore,
-          textStyle: labelTextStyle,
         ),
       );
     }
@@ -281,7 +265,6 @@ class _FileSelectionActionsWidgetState
           icon: Icons.delete_forever_outlined,
           labelText: S.of(context).permanentlyDelete,
           onTap: _permanentlyDelete,
-          textStyle: labelTextStyle,
         ),
       );
     }

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -284,16 +284,22 @@ class _FileSelectionActionsWidgetState
     );
 
     if (items.isNotEmpty) {
-      return SingleChildScrollView(
-        physics: const BouncingScrollPhysics(),
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const SizedBox(width: 8),
-            ...items,
-            const SizedBox(width: 8),
-          ],
+      return NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (overscroll) {
+          overscroll.disallowIndicator();
+          return true;
+        },
+        child: SingleChildScrollView(
+          physics: const ClampingScrollPhysics(),
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(width: 8),
+              ...items,
+              const SizedBox(width: 8),
+            ],
+          ),
         ),
       );
     } else {

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -13,6 +13,7 @@ import "package:photos/models/metadata/common_keys.dart";
 import 'package:photos/models/selected_files.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/hidden_service.dart';
+import "package:photos/theme/ente_theme.dart";
 import 'package:photos/ui/actions/collection/collection_file_actions.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 import 'package:photos/ui/collections/collection_action_sheet.dart';
@@ -87,6 +88,7 @@ class _FileSelectionActionsWidgetState
 
   @override
   Widget build(BuildContext context) {
+    final labelTextStyle = getEnteTextTheme(context).miniMuted;
     final bool showPrefix =
         split.pendingUploads.isNotEmpty || split.ownedByOtherUsers.isNotEmpty;
     final String suffix = showPrefix
@@ -118,6 +120,7 @@ class _FileSelectionActionsWidgetState
             icon: Icons.copy_outlined,
             labelText: S.of(context).copyLink,
             onTap: anyUploadedFiles ? _copyLink : null,
+            textStyle: labelTextStyle,
           ),
         );
       } else {
@@ -126,6 +129,7 @@ class _FileSelectionActionsWidgetState
             icon: Icons.link_outlined,
             labelText: S.of(context).shareLink + suffix,
             onTap: anyUploadedFiles ? _onCreatedSharedLinkClicked : null,
+            textStyle: labelTextStyle,
           ),
         );
       }
@@ -148,6 +152,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.grid_view_outlined,
           labelText: S.of(context).createCollage,
           onTap: _onCreateCollageClicked,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -163,6 +168,7 @@ class _FileSelectionActionsWidgetState
               ? S.of(context).addToEnte
               : S.of(context).addToAlbum + suffixInPending,
           onTap: anyOwnedFiles ? _addToAlbum : null,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -172,6 +178,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.arrow_forward_outlined,
           labelText: S.of(context).moveToAlbum + suffix,
           onTap: anyUploadedFiles ? _moveFiles : null,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -182,6 +189,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.remove_outlined,
           labelText: "${S.of(context).removeFromAlbum}$removeSuffix",
           onTap: removeCount > 0 ? _removeFilesFromAlbum : null,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -192,6 +200,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.delete_outline,
           labelText: S.of(context).delete + suffixInPending,
           onTap: anyOwnedFiles ? _onDeleteClick : null,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -202,6 +211,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.visibility_off_outlined,
           labelText: S.of(context).hide + suffix,
           onTap: anyUploadedFiles ? _onHideClick : null,
+          textStyle: labelTextStyle,
         ),
       );
     } else if (widget.type.showUnHideOption()) {
@@ -210,6 +220,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.visibility_off_outlined,
           labelText: S.of(context).unhide + suffix,
           onTap: _onUnhideClick,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -219,6 +230,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.archive_outlined,
           labelText: S.of(context).archive + suffix,
           onTap: anyUploadedFiles ? _onArchiveClick : null,
+          textStyle: labelTextStyle,
         ),
       );
     } else if (widget.type.showUnArchiveOption()) {
@@ -227,6 +239,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.unarchive,
           labelText: S.of(context).unarchive + suffix,
           onTap: _onUnArchiveClick,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -237,6 +250,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.favorite_border_rounded,
           labelText: S.of(context).favorite + suffix,
           onTap: anyUploadedFiles ? _onFavoriteClick : null,
+          textStyle: labelTextStyle,
         ),
       );
     } else if (widget.type.showUnFavoriteOption()) {
@@ -245,6 +259,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.favorite,
           labelText: S.of(context).removeFromFavorite + suffix,
           onTap: _onUnFavoriteClick,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -255,6 +270,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.restore_outlined,
           labelText: S.of(context).restore,
           onTap: _restore,
+          textStyle: labelTextStyle,
         ),
       );
     }
@@ -265,6 +281,7 @@ class _FileSelectionActionsWidgetState
           icon: Icons.delete_forever_outlined,
           labelText: S.of(context).permanentlyDelete,
           onTap: _permanentlyDelete,
+          textStyle: labelTextStyle,
         ),
       );
     }

--- a/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -1,31 +1,20 @@
 import 'package:flutter/material.dart';
-import "package:photos/generated/l10n.dart";
 import 'package:photos/models/collection.dart';
-import 'package:photos/models/device_collection.dart';
 import 'package:photos/models/gallery_type.dart';
-import "package:photos/models/metadata/common_keys.dart";
 import 'package:photos/models/selected_files.dart';
-import 'package:photos/theme/ente_theme.dart';
-import 'package:photos/ui/collections/collection_action_sheet.dart';
 import 'package:photos/ui/components/bottom_action_bar/bottom_action_bar_widget.dart';
-import 'package:photos/ui/components/buttons/icon_button_widget.dart';
 import 'package:photos/ui/viewer/actions/file_selection_actions_widget.dart';
-import 'package:photos/utils/delete_file_util.dart';
-import 'package:photos/utils/magic_util.dart';
-import 'package:photos/utils/share_util.dart';
 
 class FileSelectionOverlayBar extends StatefulWidget {
   final GalleryType galleryType;
   final SelectedFiles selectedFiles;
   final Collection? collection;
-  final DeviceCollection? deviceCollection;
   final Color? backgroundColor;
 
   const FileSelectionOverlayBar(
     this.galleryType,
     this.selectedFiles, {
     this.collection,
-    this.deviceCollection,
     this.backgroundColor,
     Key? key,
   }) : super(key: key);
@@ -38,17 +27,16 @@ class FileSelectionOverlayBar extends StatefulWidget {
 class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
   final GlobalKey shareButtonKey = GlobalKey();
   final ValueNotifier<bool> _hasSelectedFilesNotifier = ValueNotifier(false);
-  late bool showDeleteOption;
 
   @override
   void initState() {
     super.initState();
-    showDeleteOption = widget.galleryType.showDeleteIconOption();
     widget.selectedFiles.addListener(_selectedFilesListener);
   }
 
   @override
   void dispose() {
+    _hasSelectedFilesNotifier.dispose();
     widget.selectedFiles.removeListener(_selectedFilesListener);
     super.dispose();
   }
@@ -58,74 +46,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     debugPrint(
       '$runtimeType building with ${widget.selectedFiles.files.length}',
     );
-    final List<IconButtonWidget> iconsButton = [];
-    final iconColor = getEnteColorScheme(context).blurStrokeBase;
-    if (showDeleteOption) {
-      iconsButton.add(
-        IconButtonWidget(
-          icon: Icons.delete_outlined,
-          iconButtonType: IconButtonType.primary,
-          iconColor: iconColor,
-          onTap: () => showDeleteSheet(context, widget.selectedFiles),
-        ),
-      );
-    }
 
-    if (widget.galleryType.showUnArchiveOption()) {
-      iconsButton.add(
-        IconButtonWidget(
-          icon: Icons.unarchive,
-          iconButtonType: IconButtonType.primary,
-          iconColor: iconColor,
-          onTap: () => _onUnArchiveClick(),
-        ),
-      );
-    }
-    if (widget.galleryType.showUnHideOption()) {
-      iconsButton.add(
-        IconButtonWidget(
-          icon: Icons.visibility_off_outlined,
-          iconButtonType: IconButtonType.primary,
-          iconColor: iconColor,
-          onTap: () {
-            showCollectionActionSheet(
-              context,
-              selectedFiles: widget.selectedFiles,
-              actionType: CollectionActionType.unHide,
-            );
-          },
-        ),
-      );
-    }
-    if (widget.galleryType == GalleryType.trash) {
-      iconsButton.add(
-        IconButtonWidget(
-          icon: Icons.delete_forever_outlined,
-          iconButtonType: IconButtonType.primary,
-          iconColor: iconColor,
-          onTap: () async {
-            if (await deleteFromTrash(
-              context,
-              widget.selectedFiles.files.toList(),
-            )) {
-              widget.selectedFiles.clearAll();
-            }
-          },
-        ),
-      );
-    }
-    iconsButton.add(
-      IconButtonWidget(
-        icon: Icons.adaptive.share_outlined,
-        iconButtonType: IconButtonType.primary,
-        iconColor: iconColor,
-        onTap: () => shareSelected(
-          context,
-          shareButtonKey,
-          widget.selectedFiles.files.toList(),
-        ),
-      ),
-    );
     return ValueListenableBuilder(
       valueListenable: _hasSelectedFilesNotifier,
       builder: (context, value, child) {
@@ -140,36 +61,22 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
           firstChild: BottomActionBarWidget(
             selectedFiles: widget.selectedFiles,
             hasSmallerBottomPadding: true,
-            type: widget.galleryType,
             expandedMenu: FileSelectionActionWidget(
               widget.galleryType,
               widget.selectedFiles,
               collection: widget.collection,
             ),
-            text: S
-                .of(context)
-                .itemSelectedCount(widget.selectedFiles.files.length),
             onCancel: () {
               if (widget.selectedFiles.files.isNotEmpty) {
                 widget.selectedFiles.clearAll();
               }
             },
-            iconButtons: iconsButton,
             backgroundColor: widget.backgroundColor,
           ),
           secondChild: const SizedBox(width: double.infinity),
         );
       },
     );
-  }
-
-  Future<void> _onUnArchiveClick() async {
-    await changeVisibility(
-      context,
-      widget.selectedFiles.files.toList(),
-      visibleVisibility,
-    );
-    widget.selectedFiles.clearAll();
   }
 
   _selectedFilesListener() {

--- a/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:photos/models/collection.dart';
 import 'package:photos/models/gallery_type.dart';
 import 'package:photos/models/selected_files.dart';
+import "package:photos/theme/effects.dart";
 import 'package:photos/ui/components/bottom_action_bar/bottom_action_bar_widget.dart';
 
 class FileSelectionOverlayBar extends StatefulWidget {
@@ -45,31 +46,36 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       '$runtimeType building with ${widget.selectedFiles.files.length}',
     );
 
-    return ValueListenableBuilder(
-      valueListenable: _hasSelectedFilesNotifier,
-      builder: (context, value, child) {
-        return AnimatedCrossFade(
-          firstCurve: Curves.easeInOutExpo,
-          secondCurve: Curves.easeInOutExpo,
-          sizeCurve: Curves.easeInOutExpo,
-          crossFadeState: _hasSelectedFilesNotifier.value
-              ? CrossFadeState.showFirst
-              : CrossFadeState.showSecond,
-          duration: const Duration(milliseconds: 400),
-          firstChild: BottomActionBarWidget(
-            selectedFiles: widget.selectedFiles,
-            galleryType: widget.galleryType,
-            collection: widget.collection,
-            onCancel: () {
-              if (widget.selectedFiles.files.isNotEmpty) {
-                widget.selectedFiles.clearAll();
-              }
-            },
-            backgroundColor: widget.backgroundColor,
-          ),
-          secondChild: const SizedBox(width: double.infinity),
-        );
-      },
+    return Container(
+      decoration: BoxDecoration(
+        boxShadow: shadowFloatFaintLight,
+      ),
+      child: ValueListenableBuilder(
+        valueListenable: _hasSelectedFilesNotifier,
+        builder: (context, value, child) {
+          return AnimatedCrossFade(
+            firstCurve: Curves.easeInOutExpo,
+            secondCurve: Curves.easeInOutExpo,
+            sizeCurve: Curves.easeInOutExpo,
+            crossFadeState: _hasSelectedFilesNotifier.value
+                ? CrossFadeState.showFirst
+                : CrossFadeState.showSecond,
+            duration: const Duration(milliseconds: 400),
+            firstChild: BottomActionBarWidget(
+              selectedFiles: widget.selectedFiles,
+              galleryType: widget.galleryType,
+              collection: widget.collection,
+              onCancel: () {
+                if (widget.selectedFiles.files.isNotEmpty) {
+                  widget.selectedFiles.clearAll();
+                }
+              },
+              backgroundColor: widget.backgroundColor,
+            ),
+            secondChild: const SizedBox(width: double.infinity),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -60,7 +60,6 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
           duration: const Duration(milliseconds: 400),
           firstChild: BottomActionBarWidget(
             selectedFiles: widget.selectedFiles,
-            hasSmallerBottomPadding: true,
             expandedMenu: FileSelectionActionWidget(
               widget.galleryType,
               widget.selectedFiles,

--- a/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -24,7 +24,6 @@ class FileSelectionOverlayBar extends StatefulWidget {
 }
 
 class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
-  final GlobalKey shareButtonKey = GlobalKey();
   final ValueNotifier<bool> _hasSelectedFilesNotifier = ValueNotifier(false);
 
   @override

--- a/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -3,7 +3,6 @@ import 'package:photos/models/collection.dart';
 import 'package:photos/models/gallery_type.dart';
 import 'package:photos/models/selected_files.dart';
 import 'package:photos/ui/components/bottom_action_bar/bottom_action_bar_widget.dart';
-import 'package:photos/ui/viewer/actions/file_selection_actions_widget.dart';
 
 class FileSelectionOverlayBar extends StatefulWidget {
   final GalleryType galleryType;
@@ -60,11 +59,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
           duration: const Duration(milliseconds: 400),
           firstChild: BottomActionBarWidget(
             selectedFiles: widget.selectedFiles,
-            fileSelectionActionsWidget: FileSelectionActionsWidget(
-              widget.galleryType,
-              widget.selectedFiles,
-              collection: widget.collection,
-            ),
+            galleryType: widget.galleryType,
+            collection: widget.collection,
             onCancel: () {
               if (widget.selectedFiles.files.isNotEmpty) {
                 widget.selectedFiles.clearAll();

--- a/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -60,7 +60,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
           duration: const Duration(milliseconds: 400),
           firstChild: BottomActionBarWidget(
             selectedFiles: widget.selectedFiles,
-            expandedMenu: FileSelectionActionWidget(
+            fileSelectionActionsWidget: FileSelectionActionsWidget(
               widget.galleryType,
               widget.selectedFiles,
               collection: widget.collection,


### PR DESCRIPTION
## Description

- Redesigned selection sheet for better discoverability of actions that can be done on selected files.
- Created a new component `SelectionActionButton`.
    - It has a minimum width of 64pts
    - If there are words in it's `labelText` which when rendered has `width > 64`, it takes up the width of the largest word.
- Minor UI improvement on the albums tab.


https://github.com/ente-io/photos-app/assets/77285023/f0a29ded-23e3-45ee-b753-da6d9ab8814b


https://github.com/ente-io/photos-app/assets/77285023/a968b1be-cb60-44b6-8a23-2d25eb4b1ba4

- In the video below, `Permanently delete` button has more with and it matches the width of the longest word.

https://github.com/ente-io/photos-app/assets/77285023/19156f99-5fd3-43a6-99c8-52be12b857c7



## Test Plan

Did basic testing.