### PR TITLE
Improve logging for invalid file errors

### DIFF
--- a/lib/core/errors.dart
+++ b/lib/core/errors.dart
@@ -1,5 +1,21 @@
+enum InvalidReason {
+  assetDeleted,
+  sourceFileMissing,
+  livePhotoTypeChanged,
+  thumbnailMissing,
+  unknown,
+}
+
 class InvalidFileError extends ArgumentError {
-  InvalidFileError(String message) : super(message);
+  final InvalidReason invalidReason;
+
+  InvalidFileError(String message, {this.invalidReason = InvalidReason.unknown})
+      : super(message);
+
+  @override
+  String toString() {
+    return 'InvalidFileError: $message (reason: $invalidReason)';
+  }
 }
 
 class InvalidFileUploadState extends AssertionError {

--- a/lib/core/errors.dart
+++ b/lib/core/errors.dart
@@ -2,9 +2,11 @@ enum InvalidReason {
   assetDeleted,
   assetDeletedEvent,
   sourceFileMissing,
-  livePhotoTypeChanged,
+  livePhotoToImageTypeChanged,
+  imageToLivePhotoTypeChanged,
   livePhotoVideoMissing,
   thumbnailMissing,
+  unknown,
 }
 
 class InvalidFileError extends ArgumentError {

--- a/lib/core/errors.dart
+++ b/lib/core/errors.dart
@@ -1,25 +1,21 @@
 enum InvalidReason {
   assetDeleted,
+  assetDeletedEvent,
   sourceFileMissing,
   livePhotoTypeChanged,
+  livePhotoVideoMissing,
   thumbnailMissing,
-  unknown,
 }
 
 class InvalidFileError extends ArgumentError {
-  final InvalidReason invalidReason;
+  final InvalidReason reason;
 
-  InvalidFileError(String message, {this.invalidReason = InvalidReason.unknown})
-      : super(message);
+  InvalidFileError(String message, this.reason) : super(message);
 
   @override
   String toString() {
-    return 'InvalidFileError: $message (reason: $invalidReason)';
+    return 'InvalidFileError: $message (reason: $reason)';
   }
-}
-
-class InvalidFileUploadState extends AssertionError {
-  InvalidFileUploadState(String message) : super(message);
 }
 
 class SubscriptionAlreadyClaimedError extends Error {}

--- a/lib/models/file.dart
+++ b/lib/models/file.dart
@@ -75,7 +75,7 @@ class File extends EnteFile {
     file.deviceFolder = pathName;
     file.location =
         Location(latitude: asset.latitude, longitude: asset.longitude);
-    file.fileType = _fileTypeFromAsset(asset);
+    file.fileType = fileTypeFromAsset(asset);
     file.creationTime = parseFileCreationTime(file.title, asset);
     file.modificationTime = asset.modifiedDateTime.microsecondsSinceEpoch;
     file.fileSubType = asset.subtype;

--- a/lib/models/file.dart
+++ b/lib/models/file.dart
@@ -110,27 +110,6 @@ class File extends EnteFile {
     return creationTime;
   }
 
-  static FileType _fileTypeFromAsset(AssetEntity asset) {
-    FileType type = FileType.image;
-    switch (asset.type) {
-      case AssetType.image:
-        type = FileType.image;
-        // PHAssetMediaSubtype.photoLive.rawValue is 8
-        // This hack should go away once photos_manager support livePhotos
-        if (asset.subtype > -1 && (asset.subtype & 8) != 0) {
-          type = FileType.livePhoto;
-        }
-        break;
-      case AssetType.video:
-        type = FileType.video;
-        break;
-      default:
-        type = FileType.other;
-        break;
-    }
-    return type;
-  }
-
   Future<AssetEntity?> get getAsset {
     if (localID == null) {
       return Future.value(null);

--- a/lib/models/file_type.dart
+++ b/lib/models/file_type.dart
@@ -1,3 +1,5 @@
+import "package:photo_manager/photo_manager.dart";
+
 enum FileType {
   image,
   video,
@@ -29,6 +31,27 @@ FileType getFileType(int fileType) {
     default:
       return FileType.other;
   }
+}
+
+FileType fileTypeFromAsset(AssetEntity asset) {
+  FileType type = FileType.image;
+  switch (asset.type) {
+    case AssetType.image:
+      type = FileType.image;
+      // PHAssetMediaSubtype.photoLive.rawValue is 8
+      // This hack should go away once photos_manager support livePhotos
+      if (asset.subtype > -1 && (asset.subtype & 8) != 0) {
+        type = FileType.livePhoto;
+      }
+      break;
+    case AssetType.video:
+      type = FileType.video;
+      break;
+    default:
+      type = FileType.other;
+      break;
+  }
+  return type;
 }
 
 String getHumanReadableString(FileType fileType) {

--- a/lib/services/local_file_update_service.dart
+++ b/lib/services/local_file_update_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:core';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/errors.dart';
 import 'package:photos/db/file_updation_db.dart';
@@ -144,14 +143,13 @@ class LocalFileUpdateService {
           );
         }
         processedIDs.add(file.localID!);
-      } on InvalidFileError {
-        // if we fail to get the file, we can ignore the update
+      } on InvalidFileError catch (e) {
+        _logger.fine("Failed to check hash due to invalidfile ${file.tag}", e);
         processedIDs.add(file.localID!);
       } catch (e) {
-        _logger.severe("Failed to get file uploadData", e);
+        _logger.severe("Failed to check hash", e);
       } finally {}
     }
-    debugPrint("Deleting files ${processedIDs.length}");
     await _fileUpdationDB.deleteByLocalIDs(
       processedIDs.toList(),
       FileUpdationDB.modificationTimeUpdated,

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -112,7 +112,8 @@ class FileUploader {
             }
             return false;
           },
-          InvalidFileError("File already deleted"),
+          InvalidFileError(
+              "File already deleted", InvalidReason.assetDeletedEvent,),
         );
       }
     });


### PR DESCRIPTION
## Description
This is part 1 for diff series for fixing handling of Live Photo update when user decides to turn on/off the video part of a live photo.
Once the changes are landed, ideally we should not see invalid file error with reason livePhotoVideoMissing type.

## Test Plan

Tested locally.
