### PR TITLE
Stop invalidFileTracking and gracefully handle thumbnail gene failure during upload

### DIFF
--- a/lib/services/local_sync_service.dart
+++ b/lib/services/local_sync_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/core/configuration.dart';
+import "package:photos/core/errors.dart";
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/device_files_db.dart';
 import 'package:photos/db/file_updation_db.dart';
@@ -201,7 +202,7 @@ class LocalSyncService {
     return hasUnsyncedFiles;
   }
 
-  Future<void> trackInvalidFile(File file) async {
+  Future<void> trackInvalidFile(File file, InvalidFileError error) async {
     if (file.localID == null) {
       debugPrint("Warning: Invalid file has no localID");
       return;
@@ -211,9 +212,13 @@ class LocalSyncService {
     await _prefs.setStringList(kInvalidFileIDsKey, invalidIDs);
   }
 
+  @Deprecated(
+    "remove usage after few releases as we will switch to ignored files. Keeping it now to clear the invalid file ids from shared prefs",
+  )
   List<String> _getInvalidFileIDs() {
     if (_prefs.containsKey(kInvalidFileIDsKey)) {
-      return _prefs.getStringList(kInvalidFileIDsKey)!;
+      _prefs.remove(kInvalidFileIDsKey);
+      return <String>[];
     } else {
       return <String>[];
     }

--- a/lib/services/local_sync_service.dart
+++ b/lib/services/local_sync_service.dart
@@ -204,7 +204,7 @@ class LocalSyncService {
     return hasUnsyncedFiles;
   }
 
-  Future<void> trackInvalidFile(File file, InvalidFileError error) async {
+  Future<void> ignoreUpload(File file, InvalidFileError error) async {
     if (file.localID == null ||
         file.deviceFolder == null ||
         file.title == null) {

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -350,11 +350,11 @@ class FileUploader {
     var uploadHardFailure = false;
 
     try {
+      final bool isUpdatedFile =
+          file.uploadedFileID != null && file.updationTime == -1;
       _logger.info(
-        "Trying to upload " +
-            file.toString() +
-            ", isForced: " +
-            forcedUpload.toString(),
+        'starting ${forcedUpload ? 'forced' : ''} '
+        '${isUpdatedFile ? 're-upload' : 'upload'} of ${file.toString()}',
       );
       try {
         mediaUploadData = await getUploadDataFromEnteFile(file);
@@ -365,12 +365,8 @@ class FileUploader {
           rethrow;
         }
       }
-
       Uint8List? key;
-      final bool isUpdatedFile =
-          file.uploadedFileID != null && file.updationTime == -1;
       if (isUpdatedFile) {
-        _logger.info("File was updated " + file.toString());
         key = getFileKey(file);
       } else {
         key = null;

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -9,7 +9,6 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/errors.dart';
 import 'package:photos/core/event_bus.dart';
@@ -113,7 +112,9 @@ class FileUploader {
             return false;
           },
           InvalidFileError(
-              "File already deleted", InvalidReason.assetDeletedEvent,),
+            "File already deleted",
+            InvalidReason.assetDeletedEvent,
+          ),
         );
       }
     });
@@ -733,13 +734,23 @@ class FileUploader {
   }
 
   Future _onInvalidFileError(File file, InvalidFileError e) async {
-    final String ext = file.title == null ? "no title" : extension(file.title!);
-    _logger.severe(
-      "Invalid file: (ext: $ext) encountered: " + file.toString(),
-      e,
-    );
-    await FilesDB.instance.deleteLocalFile(file);
-    await LocalSyncService.instance.trackInvalidFile(file);
+    final bool canIgnoreFile = file.localID != null &&
+        file.deviceFolder != null &&
+        file.title != null &&
+        !file.isSharedMediaToAppSandbox;
+    final bool deleteEntry = !file.isUploaded && !canIgnoreFile;
+    if (e.reason != InvalidReason.thumbnailMissing || !canIgnoreFile) {
+      _logger.severe(
+        "Invalid file, localDelete: $deleteEntry, ignored: $canIgnoreFile",
+        e,
+      );
+    }
+    if (deleteEntry) {
+      await FilesDB.instance.deleteLocalFile(file);
+    }
+    if (canIgnoreFile) {
+      await LocalSyncService.instance.trackInvalidFile(file, e);
+    }
     throw e;
   }
 

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -749,7 +749,7 @@ class FileUploader {
       await FilesDB.instance.deleteLocalFile(file);
     }
     if (canIgnoreFile) {
-      await LocalSyncService.instance.trackInvalidFile(file, e);
+      await LocalSyncService.instance.ignoreUpload(file, e);
     }
     throw e;
   }

--- a/lib/utils/file_uploader_util.dart
+++ b/lib/utils/file_uploader_util.dart
@@ -107,7 +107,6 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(ente.File file) async {
       InvalidReason.sourceFileMissing,
     );
   }
-
   // h4ck to fetch location data if missing (thank you Android Q+) lazily only during uploads
   await _decorateEnteFileData(file, asset);
   fileHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
@@ -142,25 +141,7 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(ente.File file) async {
     zipHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
   }
 
-  thumbnailData = await asset.thumbnailDataWithSize(
-    const ThumbnailSize(thumbnailLargeSize, thumbnailLargeSize),
-    quality: thumbnailQuality,
-  );
-  if (thumbnailData == null) {
-    throw InvalidFileError(
-      "no thumbnail ${file.tag}",
-      InvalidReason.thumbnailMissing,
-    );
-  }
-  int compressionAttempts = 0;
-  while (thumbnailData!.length > thumbnailDataLimit &&
-      compressionAttempts < kMaximumThumbnailCompressionAttempts) {
-    _logger.info("Thumbnail size " + thumbnailData.length.toString());
-    thumbnailData = await compressThumbnail(thumbnailData);
-    _logger
-        .info("Compressed thumbnail size " + thumbnailData.length.toString());
-    compressionAttempts++;
-  }
+  thumbnailData = await _getThumbnailForUpload(asset, file);
   isDeleted = !(await asset.exists);
   int? h, w;
   if (asset.width != 0 && asset.height != 0) {
@@ -185,6 +166,29 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(ente.File file) async {
     width: w,
     motionPhotoStartIndex: motionPhotoStartingIndex,
   );
+}
+
+Future<Uint8List?> _getThumbnailForUpload(AssetEntity asset, ente.File file) async {
+  Uint8List? thumbnailData = await asset.thumbnailDataWithSize(
+    const ThumbnailSize(thumbnailLargeSize, thumbnailLargeSize),
+    quality: thumbnailQuality,
+  );
+  if (thumbnailData == null) {
+    throw InvalidFileError(
+      "no thumbnail ${file.tag}",
+      InvalidReason.thumbnailMissing,
+    );
+  }
+  int compressionAttempts = 0;
+  while (thumbnailData!.length > thumbnailDataLimit &&
+      compressionAttempts < kMaximumThumbnailCompressionAttempts) {
+    _logger.info("Thumbnail size " + thumbnailData.length.toString());
+    thumbnailData = await compressThumbnail(thumbnailData);
+    _logger
+        .info("Compressed thumbnail size " + thumbnailData.length.toString());
+    compressionAttempts++;
+  }
+  return thumbnailData;
 }
 
 // check if the assetType is still the same. This can happen for livePhotos


### PR DESCRIPTION
## Description
- Thumbnail generation failure won't result in backup failed error on UI.
- Stop tracking list of invalidFileIDs as they are ignored during next import. Instead, putting those entries in the list of ignored files so that they are surfaced on the device folder section.. with a message that certain files are ignored for upload.

## Test Plan

Tested locally.
