### PR TITLE
Surface ignore reason

### DIFF
--- a/lib/services/files_service.dart
+++ b/lib/services/files_service.dart
@@ -139,7 +139,7 @@ class FilesService {
   }
 
   Future<void> removeIgnoredFiles(Future<FileLoadResult> result) async {
-    final ignoredIDs = await IgnoredFilesService.instance.ignoredIDs;
+    final ignoredIDs = await IgnoredFilesService.instance.idToIgnoreReasonMap;
     (await result).files.removeWhere(
           (f) =>
               f.uploadedFileID == null &&

--- a/lib/services/filter/db_filters.dart
+++ b/lib/services/filter/db_filters.dart
@@ -33,10 +33,10 @@ Future<List<File>> applyDBFilters(
   }
   final List<Filter> filters = [];
   if (options.hideIgnoredForUpload) {
-    final Set<String> ignoredIDs =
-        await IgnoredFilesService.instance.ignoredIDs;
-    if (ignoredIDs.isNotEmpty) {
-      filters.add(UploadIgnoreFilter(ignoredIDs));
+    final Map<String, String> idToReasonMap =
+        await IgnoredFilesService.instance.idToIgnoreReasonMap;
+    if (idToReasonMap.isNotEmpty) {
+      filters.add(UploadIgnoreFilter(idToReasonMap));
     }
   }
   if (options.dedupeUploadID) {

--- a/lib/services/filter/upload_ignore.dart
+++ b/lib/services/filter/upload_ignore.dart
@@ -5,14 +5,14 @@ import "package:photos/services/ignored_files_service.dart";
 // UploadIgnoreFilter hides the unuploaded files that are ignored from for
 // upload
 class UploadIgnoreFilter extends Filter {
-  Set<String> ignoredIDs;
+  Map<String, String> idToReasonMap;
 
-  UploadIgnoreFilter(this.ignoredIDs) : super();
+  UploadIgnoreFilter(this.idToReasonMap) : super();
 
   @override
   bool filter(File file) {
     // Already uploaded files pass the filter
     if (file.isUploaded) return true;
-    return !IgnoredFilesService.instance.shouldSkipUpload(ignoredIDs, file);
+    return !IgnoredFilesService.instance.shouldSkipUpload(idToReasonMap, file);
   }
 }

--- a/lib/services/ignored_files_service.dart
+++ b/lib/services/ignored_files_service.dart
@@ -47,6 +47,14 @@ class IgnoredFilesService {
     return false;
   }
 
+  String? getUploadSkipReason(Map<String, String> idToReasonMap, File file) {
+    final id = _getIgnoreID(file.localID, file.deviceFolder, file.title);
+    if (id != null && id.isNotEmpty) {
+      return idToReasonMap[id];
+    }
+    return null;
+  }
+
   Future<bool> shouldSkipUploadAsync(File file) async {
     final ignoredID = await idToIgnoreReasonMap;
     return shouldSkipUpload(ignoredID, file);

--- a/lib/services/ignored_files_service.dart
+++ b/lib/services/ignored_files_service.dart
@@ -15,20 +15,20 @@ class IgnoredFilesService {
   static final IgnoredFilesService instance =
       IgnoredFilesService._privateConstructor();
 
-  Future<Set<String>>? _ignoredIDs;
+  Future<Map<String, String>>? _idsToReasonMap;
 
-  Future<Set<String>> get ignoredIDs async {
+  Future<Map<String, String>> get idToIgnoreReasonMap async {
     // lazily instantiate the db the first time it is accessed
-    _ignoredIDs ??= _loadExistingIDs();
-    return _ignoredIDs!;
+    _idsToReasonMap ??= _loadIDsToReasonMap();
+    return _idsToReasonMap!;
   }
 
   Future<void> cacheAndInsert(List<IgnoredFile> ignoredFiles) async {
-    final existingIDs = await ignoredIDs;
+    final existingIDs = await idToIgnoreReasonMap;
     for (IgnoredFile iFile in ignoredFiles) {
       final id = _idForIgnoredFile(iFile);
       if (id != null) {
-        existingIDs.add(id);
+        existingIDs[id] = iFile.reason;
       }
     }
     return _db.insertMultiple(ignoredFiles);
@@ -39,16 +39,16 @@ class IgnoredFilesService {
   // to avoid making it async in nature.
   // This syntax is intentional as we want to ensure that ignoredIDs are loaded
   // from the DB before calling this method.
-  bool shouldSkipUpload(Set<String> ignoredIDs, File file) {
+  bool shouldSkipUpload(Map<String, String> idToReasonMap, File file) {
     final id = _getIgnoreID(file.localID, file.deviceFolder, file.title);
     if (id != null && id.isNotEmpty) {
-      return ignoredIDs.contains(id);
+      return idToReasonMap.containsKey(id);
     }
     return false;
   }
 
   Future<bool> shouldSkipUploadAsync(File file) async {
-    final ignoredID = await ignoredIDs;
+    final ignoredID = await idToIgnoreReasonMap;
     return shouldSkipUpload(ignoredID, file);
   }
 
@@ -57,7 +57,7 @@ class IgnoredFilesService {
   Future<void> removeIgnoredMappings(List<File> files) async {
     final List<IgnoredFile> ignoredFiles = [];
     final Set<String> idsToRemoveFromCache = {};
-    final Set<String> currentlyIgnoredIDs = await ignoredIDs;
+    final Map<String, String> currentlyIgnoredIDs = await idToIgnoreReasonMap;
     for (final file in files) {
       // check if upload is not skipped for file. If not, no need to remove
       // any mapping
@@ -74,23 +74,25 @@ class IgnoredFilesService {
 
     if (ignoredFiles.isNotEmpty) {
       await _db.removeIgnoredEntries(ignoredFiles);
-      currentlyIgnoredIDs.removeAll(idsToRemoveFromCache);
+      for (final id in idsToRemoveFromCache) {
+        currentlyIgnoredIDs.remove(id);
+      }
     }
   }
 
   Future<void> reset() async {
     await _db.clearTable();
-    _ignoredIDs = null;
+    _idsToReasonMap = null;
   }
 
-  Future<Set<String>> _loadExistingIDs() async {
+  Future<Map<String, String>> _loadIDsToReasonMap() async {
     _logger.fine('loading existing IDs');
     final dbResult = await _db.getAll();
-    final Set<String> result = <String>{};
+    final Map<String, String> result = <String, String>{};
     for (IgnoredFile iFile in dbResult) {
       final id = _idForIgnoredFile(iFile);
       if (id != null) {
-        result.add(id);
+        result[id] = iFile.reason;
       }
     }
     return result;

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -192,7 +192,8 @@ class RemoteSyncService {
   }
 
   Future<void> _syncUpdatedCollections(
-      final Map<int, int> idsToRemoteUpdationTimeMap,) async {
+    final Map<int, int> idsToRemoteUpdationTimeMap,
+  ) async {
     for (final cid in idsToRemoteUpdationTimeMap.keys) {
       await _syncCollectionDiff(
         cid,
@@ -222,7 +223,7 @@ class RemoteSyncService {
   Future<void> _syncCollectionDiff(int collectionID, int sinceTime) async {
     _logger.info(
       "[Collection-$collectionID] fetch diff silently: $_isExistingSyncSilent "
-          "since: $sinceTime",
+      "since: $sinceTime",
     );
     if (!_isExistingSyncSilent) {
       Bus.instance.fire(SyncStatusUpdate(SyncStatus.applyingRemoteDiff));
@@ -492,7 +493,7 @@ class RemoteSyncService {
     }
     final bool shouldRemoveVideos =
         !_config.shouldBackupVideos() || _shouldThrottleSync();
-    final ignoredIDs = await IgnoredFilesService.instance.ignoredIDs;
+    final ignoredIDs = await IgnoredFilesService.instance.idToIgnoreReasonMap;
     bool shouldSkipUploadFunc(File file) {
       return IgnoredFilesService.instance.shouldSkipUpload(ignoredIDs, file);
     }
@@ -665,7 +666,10 @@ class RemoteSyncService {
         // Case [1] Check and clear local cache when uploadedFile already exist
         // Note: Existing file can be null here if it's replaced by the time we
         // reach here
-        existingFile = await _db.getUploadedFile(remoteFile.uploadedFileID!, remoteFile.collectionID!,);
+        existingFile = await _db.getUploadedFile(
+          remoteFile.uploadedFileID!,
+          remoteFile.collectionID!,
+        );
         if (existingFile != null &&
             _shouldClearCache(remoteFile, existingFile)) {
           needsGalleryReload = true;
@@ -860,18 +864,18 @@ class RemoteSyncService {
     // TODO: Add option to opt out of notifications for a specific collection
     // Screen: https://www.figma.com/file/SYtMyLBs5SAOkTbfMMzhqt/ente-Visual-Design?type=design&node-id=7689-52943&t=IyWOfh0Gsb0p7yVC-4
     final isForeground = AppLifecycleService.instance.isForeground;
-    final bool showNotification = NotificationService.instance
-        .shouldShowNotificationsForSharedPhotos() &&
-        isFirstRemoteSyncDone() &&
-        !isForeground;
+    final bool showNotification =
+        NotificationService.instance.shouldShowNotificationsForSharedPhotos() &&
+            isFirstRemoteSyncDone() &&
+            !isForeground;
     _logger.info(
       "[Collection-$collectionID] shouldShow notification: $showNotification, "
-          "isAppInForeground: $isForeground",
+      "isAppInForeground: $isForeground",
     );
     return showNotification;
   }
 
-  Future<void>  _notifyNewFiles(List<int> collectionIDs) async {
+  Future<void> _notifyNewFiles(List<int> collectionIDs) async {
     final userID = Configuration.instance.getUserID();
     final appOpenTime = AppLifecycleService.instance.getLastAppOpenTime();
     for (final collectionID in collectionIDs) {
@@ -882,11 +886,11 @@ class RemoteSyncService {
           await _db.getNewFilesInCollection(collectionID, appOpenTime);
       final Set<int> sharedFilesIDs = {};
       final Set<int> collectedFilesIDs = {};
-      for(final file in files) {
+      for (final file in files) {
         if (file.isUploaded && file.ownerID != userID) {
           sharedFilesIDs.add(file.uploadedFileID!);
-        } else if (file.isUploaded && file.pubMagicMetadata!.uploaderName !=
-        null) {
+        } else if (file.isUploaded &&
+            file.pubMagicMetadata!.uploaderName != null) {
           collectedFilesIDs.add(file.uploadedFileID!);
         }
       }

--- a/lib/ui/viewer/gallery/collection_page.dart
+++ b/lib/ui/viewer/gallery/collection_page.dart
@@ -56,7 +56,8 @@ class CollectionPage extends StatelessWidget {
           asc: asc,
         );
         // hide ignored files from home page UI
-        final ignoredIDs = await IgnoredFilesService.instance.ignoredIDs;
+        final ignoredIDs =
+            await IgnoredFilesService.instance.idToIgnoreReasonMap;
         result.files.removeWhere(
           (f) =>
               f.uploadedFileID == null &&

--- a/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/lib/ui/viewer/gallery/device_folder_page.dart
@@ -205,17 +205,18 @@ class _BackupHeaderWidgetState extends State<BackupHeaderWidget> {
     Future<List<File>> filesInDeviceCollection,
   ) async {
     final List<File> deviceCollectionFiles = await filesInDeviceCollection;
-
-    final ignoredIdsForFile = <String>{};
+    final allIgnoredIDs = await IgnoredFilesService.instance.ignoredIDs;
+    if (allIgnoredIDs.isEmpty) {
+      return false;
+    }
     for (File file in deviceCollectionFiles) {
       final String? ignoreID =
           IgnoredFilesService.instance.getIgnoredIDForFile(file);
-      if (ignoreID != null) {
-        ignoredIdsForFile.add(ignoreID);
+      if (ignoreID != null && allIgnoredIDs.contains(ignoreID!)) {
+        return true;
       }
     }
-    final ignoredFiles = await IgnoredFilesService.instance.ignoredIDs;
-    return ignoredFiles.intersection(ignoredIdsForFile).isNotEmpty;
+    return false;
   }
 }
 

--- a/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/lib/ui/viewer/gallery/device_folder_page.dart
@@ -205,14 +205,15 @@ class _BackupHeaderWidgetState extends State<BackupHeaderWidget> {
     Future<List<File>> filesInDeviceCollection,
   ) async {
     final List<File> deviceCollectionFiles = await filesInDeviceCollection;
-    final allIgnoredIDs = await IgnoredFilesService.instance.ignoredIDs;
+    final allIgnoredIDs =
+        await IgnoredFilesService.instance.idToIgnoreReasonMap;
     if (allIgnoredIDs.isEmpty) {
       return false;
     }
     for (File file in deviceCollectionFiles) {
       final String? ignoreID =
           IgnoredFilesService.instance.getIgnoredIDForFile(file);
-      if (ignoreID != null && allIgnoredIDs.contains(ignoreID!)) {
+      if (ignoreID != null && allIgnoredIDs.containsKey(ignoreID!)) {
         return true;
       }
     }
@@ -253,7 +254,7 @@ class _ResetIgnoredFilesWidgetState extends State<ResetIgnoredFilesWidget> {
               widget.filesInDeviceCollection,
             );
             RemoteSyncService.instance.sync(silently: true).then((value) {
-              if(mounted) {
+              if (mounted) {
                 widget.parentSetState.call();
               }
             });

--- a/lib/ui/viewer/gallery/hooks/pick_cover_photo.dart
+++ b/lib/ui/viewer/gallery/hooks/pick_cover_photo.dart
@@ -97,8 +97,8 @@ class PickCoverPhotoWidget extends StatelessWidget {
                                 asc: asc,
                               );
                               // hide ignored files from home page UI
-                              final ignoredIDs =
-                                  await IgnoredFilesService.instance.ignoredIDs;
+                              final ignoredIDs = await IgnoredFilesService
+                                  .instance.idToIgnoreReasonMap;
                               result.files.removeWhere(
                                 (f) =>
                                     f.uploadedFileID == null &&
@@ -151,8 +151,10 @@ class PickCoverPhotoWidget extends StatelessWidget {
                                   onTap: () async {
                                     final selectedFile =
                                         selectedFiles.files.first;
-                                    Navigator.pop(context, selectedFile
-                                        .uploadedFileID!,);
+                                    Navigator.pop(
+                                      context,
+                                      selectedFile.uploadedFileID!,
+                                    );
                                   },
                                 ),
                               );
@@ -169,7 +171,7 @@ class PickCoverPhotoWidget extends StatelessWidget {
                                 ? Icons.restore_outlined
                                 : null,
                             onTap: () async {
-                              if(collection.hasCover) {
+                              if (collection.hasCover) {
                                 Navigator.pop(context, 0);
                               } else {
                                 Navigator.of(context).pop();

--- a/lib/ui/viewer/gallery/uncategorized_page.dart
+++ b/lib/ui/viewer/gallery/uncategorized_page.dart
@@ -41,7 +41,8 @@ class UnCategorizedPage extends StatelessWidget {
           asc: asc,
         );
         // hide ignored files from home page UI
-        final ignoredIDs = await IgnoredFilesService.instance.ignoredIDs;
+        final ignoredIDs =
+            await IgnoredFilesService.instance.idToIgnoreReasonMap;
         result.files.removeWhere(
           (f) =>
               f.uploadedFileID == null &&


### PR DESCRIPTION
## Description
This information is intentionally hidden and not automatically thrown at users face.
For invalidFiles, where upload fails due to some issue while fetching file or thumbnail, the reason could any of the following error code. We can later refine these error messages if we actively surface them on UI.

```
assetDeleted,
  assetDeletedEvent,
  sourceFileMissing,
  livePhotoToImageTypeChanged,
  imageToLivePhotoTypeChanged,
  livePhotoVideoMissing,
  thumbnailMissing,
  unknown,
```
## Test Plan
Tested locally
