### PR TITLE
Club mutiple defaultHiddenCollections to one

### DIFF
--- a/lib/models/metadata/collection_magic.dart
+++ b/lib/models/metadata/collection_magic.dart
@@ -16,7 +16,7 @@ const orderKey = "order";
 class CollectionMagicMetadata {
   // 0 -> visible
   // 1 -> archived
-  // 2 -> hidden etc?
+  // 2 -> hidden
   int visibility;
 
   // null/0 value -> no subType

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -72,7 +72,7 @@ extension HiddenService on CollectionsService {
         ))
             .files;
         await move(result.id, defaultHidden.id, filesInCollection);
-        CollectionsService.instance.trashEmptyCollection(defaultHidden);
+        await CollectionsService.instance.trashEmptyCollection(defaultHidden);
       } on AssertionError catch (e) {
         _logger.severe("Clubbing all defaultHidden : ${e.message}");
         continue;

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -73,9 +73,6 @@ extension HiddenService on CollectionsService {
             .files;
         await move(result.id, defaultHidden.id, filesInCollection);
         await CollectionsService.instance.trashEmptyCollection(defaultHidden);
-      } on AssertionError catch (e) {
-        _logger.severe("Clubbing all defaultHidden : ${e.message}");
-        continue;
       } catch (e, s) {
         _logger.severe(
           "One iteration of clubbing all default hidden failed",

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -22,8 +22,6 @@ import 'package:photos/utils/dialog_util.dart';
 extension HiddenService on CollectionsService {
   static final _logger = Logger("HiddenCollectionService");
 
-  // getDefaultHiddenCollection will return null if there's no default
-  // collection
   Future<Collection> getDefaultHiddenCollection() async {
     Collection? defaultHidden;
     if (cachedDefaultHiddenCollection != null) {

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -62,7 +62,7 @@ extension HiddenService on CollectionsService {
 
     for (Collection defaultHidden in allDefaultHidden) {
       try {
-        if (defaultHidden == allDefaultHidden.first) {
+        if (defaultHidden.id == allDefaultHidden.first.id) {
           continue;
         }
         final filesInCollection = (await FilesDB.instance.getFilesInCollection(

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -60,7 +60,7 @@ extension HiddenService on CollectionsService {
 
     for (Collection defaultHidden in allDefaultHidden) {
       try {
-        if (defaultHidden.id == allDefaultHidden.first.id) {
+        if (defaultHidden.id == result.id) {
           continue;
         }
         final filesInCollection = (await FilesDB.instance.getFilesInCollection(

--- a/lib/ui/viewer/file_details/upload_icon_widget.dart
+++ b/lib/ui/viewer/file_details/upload_icon_widget.dart
@@ -8,7 +8,6 @@ import "package:photos/db/files_db.dart";
 import "package:photos/events/collection_updated_event.dart";
 import "package:photos/events/files_updated_event.dart";
 import "package:photos/models/file.dart";
-import "package:photos/models/ignored_file.dart";
 import "package:photos/services/collections_service.dart";
 import "package:photos/services/hidden_service.dart";
 import "package:photos/services/ignored_files_service.dart";
@@ -85,12 +84,13 @@ class _UpdateIconWidgetState extends State<UploadIconWidget> {
       }
       return const SizedBox.shrink();
     }
-    return FutureBuilder<Map<String,String>>(
+    return FutureBuilder<Map<String, String>>(
       future: ignoreService.idToIgnoreReasonMap,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
-          final Map<String,String> idsToReasonMap = snapshot.data!;
-          final ignoreReason = ignoreService.getUploadSkipReason(idsToReasonMap, widget.file);
+          final Map<String, String> idsToReasonMap = snapshot.data!;
+          final ignoreReason =
+              ignoreService.getUploadSkipReason(idsToReasonMap, widget.file);
           final bool isIgnored = ignoreReason != null;
           final bool isQueuedForUpload =
               !isIgnored && widget.file.collectionID != null;
@@ -106,7 +106,7 @@ class _UpdateIconWidgetState extends State<UploadIconWidget> {
           return Tooltip(
             message: isIgnored
                 ? "Tap to upload, upload is currently ignored due "
-                "to $ignoreReason"
+                    "to $ignoreReason"
                 : "Tap to upload",
             child: IconButton(
               icon: const Icon(


### PR DESCRIPTION
## Description

- Move files of all `defaultHiddenCollection`s to one `defaultHiddenCollection`
- Delete the excess empty `defaultHiddenCollections`
- If moving files fails, the excess collection won't be trashed. 

## Test Plan

- Tested deletion of multiple excess `defaultHiddenFiles`.
