### PR TITLE
Fix bug in handling update for remoteFile

### DIFF
--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -696,10 +696,14 @@ class RemoteSyncService {
         continue;
       }
 
-      // If remoteFile is not already synced (i.e. existingFile is null), check
-      // if the remoteFile was uploaded from this device.
+      // If remoteFile was synced before, assign the localID of the existing
+      // file entry.
+      // If remoteFile is not synced before and has localID (i.e. existingFile
+      // is null), check if the remoteFile was uploaded from this device.
       // Note: DeviceFolder is ignored for iOS during matching
-      if (existingFile == null && remoteFile.localID != null) {
+      if (existingFile != null) {
+        remoteFile.localID = existingFile.localID;
+      } else if (remoteFile.localID != null && existingFile == null) {
         final localFileEntries = await _db.getUnlinkedLocalMatchesForRemoteFile(
           userID,
           remoteFile.localID!,


### PR DESCRIPTION
## Description
Issue:

> Note: In case of Android, local IDs for a file are integers.

Device A has a file F_A_1 with localID "xzy".
Device B also has a local file F_B_1 with localID "xyz".


When file uploaded from Device A is synced to the Device B, then in that context **file F_A_1** is treated as `RemoteFile (File F_A_1 with localID 'xyz')`

When we sync file `Remote file F_A_1` for first time, there won't be any existing file in the local DB aka (existingFile is null).
In this case, we check if the remoteFile with `localID "xyz"` is uploaded from from same device by verifying that there existing a local device file with same ID, type, name and device folder. If we find a match, we store the `Remote file F_A_1` with the same local ID 'xyz' otherwise we set the localID as null.

After first sync, when we receive any update for the same `Remote file F_A_1` and we already have a reference in the DB (existingFile is *not null*), then on Device B, we are blindly storing the the `RemoteFile with same localID *xyz*` instead of using the localID that's attached in the existingFile.

This result in incorrect preview of photos because we end up fetching totally different photo from the device based on the local ID.

Related to #1279


