### PR TITLE
Fix bug in cancelling timer + bump version

### DIFF
--- a/lib/utils/fake_progress.dart
+++ b/lib/utils/fake_progress.dart
@@ -7,7 +7,7 @@ typedef FakeProgressCallback = void Function(int count);
 class FakePeriodicProgress {
   final FakeProgressCallback? callback;
   final Duration duration;
-  late Timer _timer;
+  Timer? _timer;
   bool _shouldRun = true;
   int runCount = 0;
 
@@ -24,7 +24,7 @@ class FakePeriodicProgress {
   void stop() {
     if (_shouldRun) {
       _shouldRun = false;
-      _timer.cancel();
+      _timer?.cancel();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ description: ente photos application
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 0.7.90+490
+version: 0.7.91+491
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Description
When decryption takes less than 5 second, it's resulting in error.
## Test Plan
