### PR TITLE
Fix delete when shared files are part of selection

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -361,6 +361,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "cancelSubscription":
             MessageLookupByLibrary.simpleMessage("Cancel subscription"),
         "cannotAddMorePhotosAfterBecomingViewer": m6,
+        "cannotDeleteSharedFiles":
+            MessageLookupByLibrary.simpleMessage("Cannot delete shared files"),
         "centerPoint": MessageLookupByLibrary.simpleMessage("Center point"),
         "changeEmail": MessageLookupByLibrary.simpleMessage("Change email"),
         "changePassword":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3282,6 +3282,16 @@ class S {
     );
   }
 
+  /// `Cannot delete shared files`
+  String get cannotDeleteSharedFiles {
+    return Intl.message(
+      'Cannot delete shared files',
+      name: 'cannotDeleteSharedFiles',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `The download could not be completed`
   String get theDownloadCouldNotBeCompleted {
     return Intl.message(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -468,6 +468,7 @@
   "updateAvailable": "Update available",
   "ignoreUpdate": "Ignore",
   "downloading": "Downloading...",
+  "cannotDeleteSharedFiles": "Cannot delete shared files",
   "theDownloadCouldNotBeCompleted": "The download could not be completed",
   "retry": "Retry",
   "backedUpFolders": "Backed up folders",

--- a/lib/models/files_split.dart
+++ b/lib/models/files_split.dart
@@ -13,6 +13,7 @@ class FilesSplit {
 
   int get totalFileOwnedCount =>
       pendingUploads.length + ownedByCurrentUser.length;
+  int get count => totalFileOwnedCount + ownedByOtherUsers.length;
 
   static FilesSplit split(Iterable<EnteFile> files, int currentUserID) {
     final List<EnteFile> ownedByCurrentUser = [],

--- a/lib/models/files_split.dart
+++ b/lib/models/files_split.dart
@@ -13,6 +13,7 @@ class FilesSplit {
 
   int get totalFileOwnedCount =>
       pendingUploads.length + ownedByCurrentUser.length;
+
   int get count => totalFileOwnedCount + ownedByOtherUsers.length;
 
   static FilesSplit split(Iterable<EnteFile> files, int currentUserID) {

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -383,7 +383,7 @@ class _FileSelectionActionsWidgetState
   }
 
   Future<void> _onDeleteClick() async {
-    return showDeleteSheet(context, widget.selectedFiles);
+    return showDeleteSheet(context, widget.selectedFiles, split);
   }
 
   Future<void> _removeFilesFromAlbum() async {

--- a/lib/ui/viewer/file_details/file_properties_item_widget.dart
+++ b/lib/ui/viewer/file_details/file_properties_item_widget.dart
@@ -4,6 +4,7 @@ import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/info_item_widget.dart";
+import "package:photos/utils/data_util.dart";
 import "package:photos/utils/date_time_util.dart";
 import "package:photos/utils/file_util.dart";
 import "package:photos/utils/magic_util.dart";
@@ -78,7 +79,7 @@ class _FilePropertiesItemWidgetState extends State<FilePropertiesItemWidget> {
     }
     subSectionWidgets.add(
       Text(
-        (fileSize / (1024 * 1024)).toStringAsFixed(2) + " MB",
+        formatBytes(fileSize),
         style: getEnteTextTheme(context).miniMuted,
       ),
     );


### PR DESCRIPTION
## Description
When shared files are deleted, the delete call was failing because server rejects delete request for files that are not owned by current user.

## Test Plan
Tested locally
