### PR TITLE
fix: Include 90, -90 in valid lat range and 180, -180 in valid lng range

### DIFF
--- a/lib/models/location/location.dart
+++ b/lib/models/location/location.dart
@@ -42,10 +42,10 @@ class Location with _$Location {
     if (longitude.isNaN || longitude.isInfinite) {
       return false;
     }
-    if (latitude > 90 || latitude < -90) {
+    if (latitude >= 90 || latitude <= -90) {
       return false;
     }
-    if (longitude > 180 || longitude < -180) {
+    if (longitude >= 180 || longitude <= -180) {
       return false;
     }
     return true;


### PR DESCRIPTION
## Description

From the package that we use:

https://github.com/jifalops/dart-latlong/blob/806427bf2cd59c54983cc7e04a11243447b6db0d/lib/latlong/LatLng.dart#L32C46-L32C46
