### PR TITLE
Use video player for grapheneOS and divestOS

### DIFF
--- a/lib/ui/viewer/file/file_widget.dart
+++ b/lib/ui/viewer/file/file_widget.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
+import "package:photos/ui/viewer/file/video_widget.dart";
 import "package:photos/ui/viewer/file/video_widget_new.dart";
 import "package:photos/ui/viewer/file/zoomable_live_image_new.dart";
+import "package:photos/utils/device_info.dart";
 
 class FileWidget extends StatelessWidget {
   final EnteFile file;
@@ -38,17 +40,20 @@ class FileWidget extends StatelessWidget {
         key: key ?? ValueKey(fileKey),
       );
     } else if (file.fileType == FileType.video) {
-      // return VideoWidget(
-      //   file,
-      //   autoPlay: autoPlay ?? false, // Autoplay if it was opened directly
-      //   tagPrefix: tagPrefix,
-      //   playbackCallback: playbackCallback,
-      // );
-      return VideoWidgetNew(
-        file,
-        tagPrefix: tagPrefix,
-        playbackCallback: playbackCallback,
-      );
+      if (isCompatibleWithMediaKit()) {
+        return VideoWidgetNew(
+          file,
+          tagPrefix: tagPrefix,
+          playbackCallback: playbackCallback,
+        );
+      } else {
+        return VideoWidget(
+          file,
+          autoPlay: autoPlay ?? false, // Autoplay if it was opened directly
+          tagPrefix: tagPrefix,
+          playbackCallback: playbackCallback,
+        );
+      }
     } else {
       Logger('FileWidget').severe('unsupported file type ${file.fileType}');
       return const Icon(Icons.error);

--- a/lib/utils/device_info.dart
+++ b/lib/utils/device_info.dart
@@ -54,7 +54,7 @@ Future<bool> isAndroidSDKVersionLowerThan(int inputSDK) async {
 
 bool isCompatibleWithMediaKit() {
   final os = Platform.operatingSystem.toLowerCase();
-  if (os == "grapheneos" || os == "divestos") {
+  if (os.contains("graphene") || os.contains("divest")) {
     Logger("device_info").info("os is $os, using video_player for videos");
     return false;
   }

--- a/lib/utils/device_info.dart
+++ b/lib/utils/device_info.dart
@@ -51,3 +51,13 @@ Future<bool> isAndroidSDKVersionLowerThan(int inputSDK) async {
     return false;
   }
 }
+
+bool isCompatibleWithMediaKit() {
+  final os = Platform.operatingSystem.toLowerCase();
+  if (os == "grapheneos" || os == "divestos") {
+    Logger("device_info").info("os is $os, using video_player for videos");
+    return false;
+  }
+  Logger("device_info").info("os is $os, using media_kit for videos");
+  return true;
+}

--- a/lib/utils/device_info.dart
+++ b/lib/utils/device_info.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import "package:device_info/device_info.dart";
+import "package:device_info_plus/device_info_plus.dart";
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -348,22 +348,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
-  device_info:
+  device_info_plus:
     dependency: "direct main"
     description:
-      name: device_info
-      sha256: f4a8156cb7b7480d969cb734907d18b333c8f0bc0b1ad0b342cdcecf30d62c48
+      name: device_info_plus
+      sha256: "86add5ef97215562d2e090535b0a16f197902b10c369c558a100e74ea06e8659"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
-  device_info_platform_interface:
+    version: "9.0.3"
+  device_info_plus_platform_interface:
     dependency: transitive
     description:
-      name: device_info_platform_interface
-      sha256: b148e0bf9640145d09a4f8dea96614076f889e7f7f8b5ecab1c7e5c2dbc73c1b
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "7.0.0"
   dio:
     dependency: "direct main"
     description:
@@ -2319,6 +2319,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.4"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   crypto: ^3.0.2
   cupertino_icons: ^1.0.0
   defer_pointer: ^0.0.2
-  device_info: ^2.0.2
+  device_info_plus: ^9.0.3
   dio: ^4.0.6
   dots_indicator: ^2.0.0
   dotted_border: ^2.0.0+2


### PR DESCRIPTION
## Description

Using `media_kit` for videos crashes the app on grapheneOS and divestOS. Use `video_player` in such cases.

