### PR TITLE
fix(gallery): groups in gallery show old state when scrolling back to them after updation

### DIFF
--- a/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
+++ b/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
@@ -137,10 +137,18 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
           dayStartTime.microsecondsSinceEpoch + microSecondsInDay - 1,
           asc: GalleryContextState.of(context)!.sortOrderAsc,
         );
-        if (mounted) {
-          setState(() {
-            _files = result.files;
-          });
+
+        //When items are updated in a LazyGroupGallery, only it rebuilds with the
+        //new state of _files which is a state variable in it's state object.
+        //widget.files does not change as the Widget itself is immutable. So
+        //to create a new Widget of LazyLoadingGallery with the updated
+        //widget.files, we have to call setState from an ancestor state object.
+        //[galleryState] will never be null except when LazyLoadingGallery is
+        //used without Gallery as an ancestor.
+        final galleryState = context.findAncestorStateOfType<GalleryState>();
+        if (galleryState?.mounted ?? false) {
+          galleryState!.setState(() {});
+          _files = result.files;
         }
       } else if (kDebugMode) {
         debugPrint("Unexpected event ${event.type.name}");

--- a/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
+++ b/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
@@ -140,9 +140,13 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
 
         //When items are updated in a LazyGroupGallery, only it rebuilds with the
         //new state of _files which is a state variable in it's state object.
-        //widget.files does not change as the Widget itself is immutable. So
-        //to create a new Widget of LazyLoadingGallery with the updated
-        //widget.files, we have to call setState from an ancestor state object.
+        //widget.files is not updated. Calling setState from it's ancestor
+        //state object 'Gallery' creates a new LazyLoadingGallery widget with
+        //updated widget.files
+
+        //If widget.files is kept in it's old state, the old state will come
+        //up when scrolled down and back up to the group.
+
         //[galleryState] will never be null except when LazyLoadingGallery is
         //used without Gallery as an ancestor.
         final galleryState = context.findAncestorStateOfType<GalleryState>();

--- a/lib/ui/viewer/gallery/gallery.dart
+++ b/lib/ui/viewer/gallery/gallery.dart
@@ -83,15 +83,15 @@ class Gallery extends StatefulWidget {
 
   @override
   State<Gallery> createState() {
-    return _GalleryState();
+    return GalleryState();
   }
 }
 
-class _GalleryState extends State<Gallery> {
+class GalleryState extends State<Gallery> {
   static const int kInitialLoadLimit = 100;
 
   late Logger _logger;
-  List<List<EnteFile>> _currentGroupedFiles = [];
+  List<List<EnteFile>> currentGroupedFiles = [];
   bool _hasLoadedFiles = false;
   late ItemScrollController _itemScroller;
   StreamSubscription<FilesUpdatedEvent>? _reloadEventSubscription;
@@ -197,17 +197,17 @@ class _GalleryState extends State<Gallery> {
   bool _onFilesLoaded(List<EnteFile> files) {
     final updatedGroupedFiles =
         widget.enableFileGrouping ? _groupFiles(files) : [files];
-    if (_currentGroupedFiles.length != updatedGroupedFiles.length ||
-        _currentGroupedFiles.isEmpty) {
+    if (currentGroupedFiles.length != updatedGroupedFiles.length ||
+        currentGroupedFiles.isEmpty) {
       if (mounted) {
         setState(() {
           _hasLoadedFiles = true;
-          _currentGroupedFiles = updatedGroupedFiles;
+          currentGroupedFiles = updatedGroupedFiles;
         });
       }
       return true;
     } else {
-      _currentGroupedFiles = updatedGroupedFiles;
+      currentGroupedFiles = updatedGroupedFiles;
       return false;
     }
   }
@@ -233,7 +233,7 @@ class _GalleryState extends State<Gallery> {
       inSelectionMode: widget.inSelectionMode,
       child: MultipleGroupsGalleryView(
         itemScroller: _itemScroller,
-        groupedFiles: _currentGroupedFiles,
+        groupedFiles: currentGroupedFiles,
         disableScroll: widget.disableScroll,
         emptyState: widget.emptyState,
         asyncLoader: widget.asyncLoader,


### PR DESCRIPTION
## Description

When items are added or removed from a `LazyLoadingGallery`, the `LazyLoadingGallery` immediately updates to the new state but upon scrolling down and coming back to it, the old state appears. This is because when the `LazyLoadingGallery` goes out of view, it gets disposed and it's state object also gets destroyed. When coming back to it, it uses widget.files, which hasn't been updated. Calling setState of `Gallery` widget which is an ancestor of `LazyLoadingGallery` fixes.
