### PR TITLE
fix: video continues playing after going to the next memory

### DIFF
--- a/lib/ui/home/memories/full_screen_memory.dart
+++ b/lib/ui/home/memories/full_screen_memory.dart
@@ -10,7 +10,6 @@ import "package:photos/models/memory.dart";
 import "package:photos/services/memories_service.dart";
 import "package:photos/theme/text_style.dart";
 import "package:photos/ui/actions/file/file_actions.dart";
-import "package:photos/ui/extents_page_view.dart";
 import "package:photos/ui/viewer/file/file_widget.dart";
 import "package:photos/ui/viewer/file_details/favorite_widget.dart";
 import "package:photos/utils/file_util.dart";
@@ -316,7 +315,7 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
           }
         }
       },
-      child: ExtentsPageView.extents(
+      child: PageView.builder(
         itemBuilder: (BuildContext context, int index) {
           if (index < widget.memories.length - 1) {
             final nextFile = widget.memories[index + 1].file;

--- a/lib/ui/home/memories/memories_widget.dart
+++ b/lib/ui/home/memories/memories_widget.dart
@@ -92,9 +92,9 @@ class _MemoriesWidgetState extends State<MemoriesWidget> {
 
   bool _areMemoriesFromSameYear(Memory first, Memory second) {
     final firstDate =
-    DateTime.fromMicrosecondsSinceEpoch(first.file.creationTime!);
+        DateTime.fromMicrosecondsSinceEpoch(first.file.creationTime!);
     final secondDate =
-    DateTime.fromMicrosecondsSinceEpoch(second.file.creationTime!);
+        DateTime.fromMicrosecondsSinceEpoch(second.file.creationTime!);
     return firstDate.year == secondDate.year;
   }
 }


### PR DESCRIPTION
## Description

Videos kept playing till the 2 or 3rd swipe because the off screen pages were not getting disposed till then. Using `PageView.builder` solves this problem as it unmounts and disposes offscreen pages.