### PR TITLE
Perf fixes for Search tab

### DIFF
--- a/lib/states/all_sections_examples_state.dart
+++ b/lib/states/all_sections_examples_state.dart
@@ -32,7 +32,7 @@ class _AllSectionsExamplesProviderState
   final _logger = Logger("AllSectionsExamplesProvider");
 
   final _debouncer =
-      Debouncer(const Duration(seconds: 3), executionInterval: 6000);
+      Debouncer(const Duration(seconds: 3), executionIntervalInSeconds: 6000);
   @override
   void initState() {
     super.initState();

--- a/lib/states/all_sections_examples_state.dart
+++ b/lib/states/all_sections_examples_state.dart
@@ -31,8 +31,11 @@ class _AllSectionsExamplesProviderState
   late StreamSubscription<FilesUpdatedEvent> _filesUpdatedEvent;
   final _logger = Logger("AllSectionsExamplesProvider");
 
-  final _debouncer =
-      Debouncer(const Duration(seconds: 3), executionIntervalInSeconds: 6000);
+  final _debouncer = Debouncer(
+    const Duration(seconds: 5),
+    executionIntervalInMilliSeconds: 15000,
+  );
+
   @override
   void initState() {
     super.initState();
@@ -44,9 +47,10 @@ class _AllSectionsExamplesProviderState
   }
 
   void reloadAllSections() {
+    _logger.info('_debounceTimer: queue timer');
     _debouncer.run(() async {
       setState(() {
-        _logger.info("reloading all sections in search tab");
+        _logger.info("'_debounceTimer: reloading all sections in search tab");
         final allSectionsExamples = <Future<List<SearchResult>>>[];
         for (SectionType sectionType in SectionType.values) {
           if (sectionType == SectionType.face ||

--- a/lib/states/all_sections_examples_state.dart
+++ b/lib/states/all_sections_examples_state.dart
@@ -32,7 +32,7 @@ class _AllSectionsExamplesProviderState
   final _logger = Logger("AllSectionsExamplesProvider");
 
   final _debouncer = Debouncer(
-    const Duration(seconds: 5),
+    const Duration(seconds: 4),
     executionIntervalInMilliSeconds: 15000,
   );
 

--- a/lib/ui/map/map_view.dart
+++ b/lib/ui/map/map_view.dart
@@ -40,8 +40,8 @@ class MapView extends StatefulWidget {
 
 class _MapViewState extends State<MapView> {
   late List<Marker> _markers;
-  final _debouncer =
-      Debouncer(const Duration(milliseconds: 300), executionInterval: 750);
+  final _debouncer = Debouncer(const Duration(milliseconds: 300),
+      executionIntervalInSeconds: 750);
 
   @override
   void initState() {

--- a/lib/ui/map/map_view.dart
+++ b/lib/ui/map/map_view.dart
@@ -40,8 +40,10 @@ class MapView extends StatefulWidget {
 
 class _MapViewState extends State<MapView> {
   late List<Marker> _markers;
-  final _debouncer = Debouncer(const Duration(milliseconds: 300),
-      executionIntervalInSeconds: 750);
+  final _debouncer = Debouncer(
+    const Duration(milliseconds: 300),
+    executionIntervalInMilliSeconds: 750,
+  );
 
   @override
   void initState() {

--- a/lib/ui/notification/update/change_log_page.dart
+++ b/lib/ui/notification/update/change_log_page.dart
@@ -7,7 +7,6 @@ import 'package:photos/ui/components/divider_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/ui/notification/update/change_log_entry.dart';
-import "package:photos/utils/black_friday_util.dart";
 
 class ChangeLogPage extends StatefulWidget {
   const ChangeLogPage({

--- a/lib/utils/debouncer.dart
+++ b/lib/utils/debouncer.dart
@@ -9,17 +9,18 @@ class Debouncer {
   ///in milliseconds
   final ValueNotifier<bool> _debounceActiveNotifier = ValueNotifier(false);
 
-  /// If executionInterval is not null, then the debouncer will execute the
+  /// If executionIntervalInSeconds is not null, then the debouncer will execute the
   /// current callback it has in run() method repeatedly in the given interval.
-  final int? executionInterval;
+  /// This is useful for example when you want to execute a callback every 5 seconds
+  final int? executionIntervalInSeconds;
   Timer? _debounceTimer;
 
-  Debouncer(this._duration, {this.executionInterval});
+  Debouncer(this._duration, {this.executionIntervalInSeconds});
 
   final Stopwatch _stopwatch = Stopwatch();
 
   void run(FutureVoidCallback fn) {
-    if (executionInterval != null) {
+    if (executionIntervalInSeconds != null) {
       runCallbackIfIntervalTimeElapses(fn);
     }
 
@@ -41,7 +42,7 @@ class Debouncer {
 
   runCallbackIfIntervalTimeElapses(FutureVoidCallback fn) {
     _stopwatch.isRunning ? null : _stopwatch.start();
-    if (_stopwatch.elapsedMilliseconds > executionInterval!) {
+    if (_stopwatch.elapsedMilliseconds > executionIntervalInSeconds!) {
       _stopwatch.reset();
       fn();
     }


### PR DESCRIPTION
## Description
* Fixed bug in debouncer where we were not resetting the clock. Also simplified the code.
* For FileUpdates, only reload the search screen if the user is on search tab. If they are not on search tab, we keep a track of pending updates and queue it once they tap on search screen. This will ensure that when files updates are happening due to whatever reason, we are not redundantly reloading the search tabs.

## Test Plan
Tested locally.
