### PR TITLE
Fix warnings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,9 +104,11 @@ Future<void> _runBackgroundTask(String taskId, {String mode = 'normal'}) async {
     await _sync('bgTaskActiveProcess');
     BackgroundFetch.finish(taskId);
   } else {
+    // ignore: unawaited_futures
     _runWithLogs(
       () async {
         _logger.info("Starting background task in $mode mode");
+        // ignore: unawaited_futures
         _runInBackground(taskId);
       },
       prefix: "[bg]",
@@ -150,7 +152,7 @@ Future<void> _init(bool isBackground, {String via = ''}) async {
   _logger.info("Initializing...  inBG =$isBackground via: $via");
   final SharedPreferences preferences = await SharedPreferences.getInstance();
   await _logFGHeartBeatInfo();
-  _scheduleHeartBeat(preferences, isBackground);
+  unawaited(_scheduleHeartBeat(preferences, isBackground));
   AppLifecycleService.instance.init(preferences);
   if (isBackground) {
     AppLifecycleService.instance.onAppInBackground('init via: $via');
@@ -182,13 +184,14 @@ Future<void> _init(bool isBackground, {String via = ''}) async {
   SearchService.instance.init();
   StorageBonusService.instance.init(preferences);
   if (Platform.isIOS) {
+    // ignore: unawaited_futures
     PushService.instance.init().then((_) {
       FirebaseMessaging.onBackgroundMessage(
         _firebaseMessagingBackgroundHandler,
       );
     });
   }
-  FeatureFlagService.instance.init();
+  unawaited(FeatureFlagService.instance.init());
 
   // Can not including existing tf/ml binaries as they are not being built
   // from source.
@@ -238,6 +241,7 @@ Future<void> _scheduleHeartBeat(
     DateTime.now().microsecondsSinceEpoch,
   );
   Future.delayed(kHeartBeatFrequency, () async {
+    // ignore: unawaited_futures
     _scheduleHeartBeat(prefs, isBackground);
   });
 }
@@ -277,7 +281,7 @@ Future<void> _killBGTask([String? taskId]) async {
     DateTime.now().microsecondsSinceEpoch,
   );
   final prefs = await SharedPreferences.getInstance();
-  prefs.remove(kLastBGTaskHeartBeatTime);
+  await prefs.remove(kLastBGTaskHeartBeatTime);
   if (taskId != null) {
     BackgroundFetch.finish(taskId);
   }
@@ -295,6 +299,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     }
   } else {
     // App is dead
+    // ignore: unawaited_futures
     _runWithLogs(
       () async {
         _logger.info("Background push received");

--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -147,7 +147,7 @@ class CollectionsService {
       );
     }
     await _updateDB(updatedCollections);
-    _prefs.setInt(_collectionsSyncTimeKey, maxUpdationTime);
+    await _prefs.setInt(_collectionsSyncTimeKey, maxUpdationTime);
     watch.logAndReset("till DB insertion ${updatedCollections.length}");
     for (final collection in fetchedCollections) {
       _cacheLocalPathAndCollection(collection);

--- a/lib/services/entity_service.dart
+++ b/lib/services/entity_service.dart
@@ -143,7 +143,7 @@ class EntityService {
         await _db.upsertEntities(entities);
       }
     }
-    _prefs.setInt(_getEntityLastSyncTimePrefix(type), maxSyncTime);
+    await _prefs.setInt(_getEntityLastSyncTimePrefix(type), maxSyncTime);
     if (hasMoreItems) {
       _logger.info("Diff limit reached, pulling again");
       await _remoteToLocalSync(type);

--- a/lib/services/feature_flag_service.dart
+++ b/lib/services/feature_flag_service.dart
@@ -83,7 +83,7 @@ class FeatureFlagService {
           .getDio()
           .get("https://static.ente.io/feature_flags.json");
       final flagsResponse = FeatureFlags.fromMap(response.data);
-      _prefs.setString(_featureFlagsKey, flagsResponse.toJson());
+      await _prefs.setString(_featureFlagsKey, flagsResponse.toJson());
       _featureFlags = flagsResponse;
     } catch (e) {
       _logger.severe("Failed to sync feature flags ", e);

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -149,7 +150,7 @@ extension HiddenService on CollectionsService {
       await dialog.hide();
     } on AssertionError catch (e) {
       await dialog.hide();
-      showErrorDialog(context, "Oops", e.message as String);
+      unawaited(showErrorDialog(context, "Oops", e.message as String));
       return false;
     } catch (e, s) {
       _logger.severe("Could not hide", e, s);

--- a/lib/services/local_authentication_service.dart
+++ b/lib/services/local_authentication_service.dart
@@ -24,7 +24,7 @@ class LocalAuthenticationService {
         Configuration.instance.shouldShowLockScreen(),
       );
       if (!result) {
-        unawaited(showToast(context, infoMessage));
+        showToast(context, infoMessage);
         return false;
       } else {
         return true;

--- a/lib/services/local_sync_service.dart
+++ b/lib/services/local_sync_service.dart
@@ -352,7 +352,7 @@ class LocalSyncService {
     PhotoManager.addChangeCallback((value) async {
       _logger.info("Something changed on disk");
       _changeCallbackDebouncer.run(() async {
-        checkAndSync();
+        unawaited(checkAndSync());
       });
     });
     PhotoManager.startChangeNotify();
@@ -363,9 +363,9 @@ class LocalSyncService {
       await _existingSync!.future;
     }
     if (hasGrantedLimitedPermissions()) {
-      syncAll();
+      unawaited(syncAll());
     } else {
-      sync().then((value) => _refreshDeviceFolderCountAndCover());
+      unawaited(sync().then((value) => _refreshDeviceFolderCountAndCover()));
     }
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -75,7 +75,7 @@ class NotificationService {
           ?.requestPermission();
     }
     if (result != null) {
-      _preferences.setBool(keyGrantedNotificationPermission, result);
+      await _preferences.setBool(keyGrantedNotificationPermission, result);
     }
   }
 

--- a/lib/services/push_service.dart
+++ b/lib/services/push_service.dart
@@ -35,6 +35,7 @@ class PushService {
         await _configurePushToken();
       } else {
         Bus.instance.on<SignedInEvent>().listen((_) async {
+          // ignore: unawaited_futures
           _configurePushToken();
         });
       }

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -73,6 +73,7 @@ class RemoteSyncService {
     Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) async {
       if (event.type == EventType.addedOrUpdated) {
         if (_existingSync == null) {
+          // ignore: unawaited_futures
           sync();
         }
       }
@@ -140,6 +141,7 @@ class RemoteSyncService {
         if (hasMoreFilesToBackup && !_shouldThrottleSync()) {
           // Skipping a resync to ensure that files that were ignored in this
           // session are not processed now
+          // ignore: unawaited_futures
           sync();
         } else {
           _logger.info("Fire backup completed event");
@@ -957,6 +959,7 @@ class RemoteSyncService {
           'creating notification for ${collection?.displayName} '
           'shared: $sharedFilesIDs, collected: $collectedFilesIDs files',
         );
+        // ignore: unawaited_futures
         NotificationService.instance.showNotification(
           collection!.displayName,
           totalCount.toString() + " new 📸",

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -240,6 +240,7 @@ class SyncService {
     final now = DateTime.now().microsecondsSinceEpoch;
     if ((now - lastNotificationShownTime) > microSecondsInDay) {
       await _prefs.setInt(kLastStorageLimitExceededNotificationPushTime, now);
+      // ignore: unawaited_futures
       NotificationService.instance.showNotification(
         "Storage limit exceeded",
         "Sorry, we had to pause your backups",

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -86,6 +86,7 @@ class UpdateService {
     if (shouldUpdate &&
         hasBeen3DaysSinceLastNotification &&
         _latestVersion!.shouldNotify) {
+      // ignore: unawaited_futures
       NotificationService.instance.showNotification(
         "Update available",
         "Click to install our best version yet",

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -740,8 +740,7 @@ class UserService {
       );
       await dialog.hide();
       if (response.statusCode == 200) {
-        showShortToast(context, S.of(context).authenticationSuccessful)
-            .ignore();
+        showShortToast(context, S.of(context).authenticationSuccessful);
         await _saveConfiguration(response);
         await Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
@@ -756,7 +755,7 @@ class UserService {
       await dialog.hide();
       _logger.severe(e);
       if (e.response != null && e.response!.statusCode == 404) {
-        showToast(context, "Session expired").ignore();
+        showToast(context, "Session expired");
         await Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
             builder: (BuildContext context) {
@@ -810,7 +809,7 @@ class UserService {
     } on DioError catch (e) {
       _logger.severe(e);
       if (e.response != null && e.response!.statusCode == 404) {
-        showToast(context, S.of(context).sessionExpired).ignore();
+        showToast(context, S.of(context).sessionExpired);
         Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
             builder: (BuildContext context) {
@@ -1016,11 +1015,9 @@ class UserService {
       );
       await dialog.hide();
       Bus.instance.fire(TwoFactorStatusChangeEvent(false));
-      unawaited(
-        showShortToast(
-          context,
-          S.of(context).twofactorAuthenticationHasBeenDisabled,
-        ),
+      showShortToast(
+        context,
+        S.of(context).twofactorAuthenticationHasBeenDisabled,
       );
     } catch (e) {
       await dialog.hide();

--- a/lib/ui/account/delete_account_page.dart
+++ b/lib/ui/account/delete_account_page.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import 'dart:convert';
 
 import "package:dropdown_button2/dropdown_button2.dart";
@@ -344,6 +345,7 @@ class _DeleteAccountPageState extends State<DeleteAccountPage> {
       ],
     );
 
+    // ignore: unawaited_futures
     showDialog(
       context: context,
       builder: (BuildContext context) {

--- a/lib/ui/account/login_page.dart
+++ b/lib/ui/account/login_page.dart
@@ -68,7 +68,7 @@ class _LoginPageState extends State<LoginPage> {
         isFormValid: _emailIsValid,
         buttonText: S.of(context).logInLabel,
         onPressedFunction: () async {
-          UserService.instance.setEmail(_email!);
+          await UserService.instance.setEmail(_email!);
           SrpAttributes? attr;
           bool isEmailVerificationEnabled = true;
           try {
@@ -80,6 +80,7 @@ class _LoginPageState extends State<LoginPage> {
             }
           }
           if (attr != null && !isEmailVerificationEnabled) {
+            // ignore: unawaited_futures
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (BuildContext context) {

--- a/lib/ui/account/password_entry_page.dart
+++ b/lib/ui/account/password_entry_page.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
@@ -445,6 +447,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
           await dialog.hide();
           Configuration.instance.setVolatilePassword(null);
           Bus.instance.fire(AccountConfiguredEvent());
+          // ignore: unawaited_futures
           Navigator.of(context).pushAndRemoveUntil(
             MaterialPageRoute(
               builder: (BuildContext context) {
@@ -460,6 +463,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
         }
       }
 
+      // ignore: unawaited_futures
       routeToPage(
         context,
         RecoveryKeyPage(
@@ -475,6 +479,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
       _logger.severe(e);
       await dialog.hide();
       if (e is UnsupportedError) {
+        // ignore: unawaited_futures
         showErrorDialog(
           context,
           S.of(context).insecureDevice,

--- a/lib/ui/account/password_reentry_page.dart
+++ b/lib/ui/account/password_reentry_page.dart
@@ -120,6 +120,7 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
           firstButtonLabel: S.of(context).useRecoveryKey,
         );
         if (dialogChoice!.action == ButtonAction.first) {
+          // ignore: unawaited_futures
           Navigator.of(context).push(
             MaterialPageRoute(
               builder: (BuildContext context) {

--- a/lib/ui/account/recovery_key_page.dart
+++ b/lib/ui/account/recovery_key_page.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import 'dart:io';
 
 import 'package:bip39/bip39.dart' as bip39;

--- a/lib/ui/account/recovery_page.dart
+++ b/lib/ui/account/recovery_page.dart
@@ -54,6 +54,7 @@ class _RecoveryPageState extends State<RecoveryPage> {
             await Configuration.instance.recover(_recoveryKey.text.trim());
             await dialog.hide();
             showShortToast(context, S.of(context).recoverySuccessful);
+            // ignore: unawaited_futures
             Navigator.of(context).pushReplacement(
               MaterialPageRoute(
                 builder: (BuildContext context) {
@@ -72,6 +73,7 @@ class _RecoveryPageState extends State<RecoveryPage> {
             if (e is AssertionError) {
               errMessage = '$errMessage : ${e.message}';
             }
+            // ignore: unawaited_futures
             showErrorDialog(
               context,
               S.of(context).incorrectRecoveryKeyTitle,

--- a/lib/ui/account/request_pwd_verification_page.dart
+++ b/lib/ui/account/request_pwd_verification_page.dart
@@ -85,7 +85,7 @@ class _RequestPasswordVerificationPageState
         onPressedFunction: () async {
           FocusScope.of(context).unfocus();
           final dialog = createProgressDialog(context, context.l10n.pleaseWait);
-          dialog.show();
+          await dialog.show();
           try {
             final attributes = Configuration.instance.getKeyAttributes()!;
             final Uint8List keyEncryptionKey = await CryptoUtil.deriveKey(
@@ -99,17 +99,18 @@ class _RequestPasswordVerificationPageState
               keyEncryptionKey,
               Sodium.base642bin(attributes.keyDecryptionNonce),
             );
-            dialog.show();
+            await dialog.show();
             // pop
             await widget.onPasswordVerified(keyEncryptionKey);
-            dialog.hide();
+            await dialog.hide();
             Navigator.of(context).pop(true);
           } catch (e, s) {
             _logger.severe("Error while verifying password", e, s);
-            dialog.hide();
+            await dialog.hide();
             if (widget.onPasswordError != null) {
               widget.onPasswordError!();
             } else {
+              // ignore: unawaited_futures
               showErrorDialog(
                 context,
                 context.l10n.incorrectPasswordTitle,

--- a/lib/ui/account/sessions_page.dart
+++ b/lib/ui/account/sessions_page.dart
@@ -121,6 +121,7 @@ class _SessionsPageState extends State<SessionsPage> {
     } catch (e) {
       await dialog.hide();
       _logger.severe('failed to terminate');
+      // ignore: unawaited_futures
       showErrorDialog(
         context,
         S.of(context).oops,
@@ -184,7 +185,7 @@ class _SessionsPageState extends State<SessionsPage> {
             if (isLoggingOutFromThisDevice) {
               await UserService.instance.logout(context);
             } else {
-              _terminateSession(session);
+              await _terminateSession(session);
             }
           },
         ),

--- a/lib/ui/account/two_factor_authentication_page.dart
+++ b/lib/ui/account/two_factor_authentication_page.dart
@@ -114,7 +114,7 @@ class _TwoFactorAuthenticationPageState
           child: OutlinedButton(
             onPressed: _code.length == 6
                 ? () async {
-                    _verifyTwoFactorCode(_code);
+                    await _verifyTwoFactorCode(_code);
                   }
                 : null,
             child: Text(S.of(context).verify),

--- a/lib/ui/account/two_factor_setup_page.dart
+++ b/lib/ui/account/two_factor_setup_page.dart
@@ -251,7 +251,7 @@ class _TwoFactorSetupPageState extends State<TwoFactorSetupPage>
         OutlinedButton(
           onPressed: _code.length == 6
               ? () async {
-                  _enableTwoFactor(_code);
+                  await _enableTwoFactor(_code);
                 }
               : null,
           child: Text(S.of(context).confirm),

--- a/lib/ui/account/verify_recovery_page.dart
+++ b/lib/ui/account/verify_recovery_page.dart
@@ -97,6 +97,7 @@ class _VerifyRecoveryPageState extends State<VerifyRecoveryPage> {
         recoveryKey = CryptoUtil.bin2hex(
           await UserService.instance.getOrCreateRecoveryKey(context),
         );
+        // ignore: unawaited_futures
         routeToPage(
           context,
           RecoveryKeyPage(

--- a/lib/ui/actions/collection/collection_file_actions.dart
+++ b/lib/ui/actions/collection/collection_file_actions.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import 'package:flutter/cupertino.dart';
 import "package:photo_manager/photo_manager.dart";
 import "package:photos/core/configuration.dart";
@@ -184,7 +186,7 @@ extension CollectionFileActions on CollectionActions {
       if (files.isNotEmpty) {
         await CollectionsService.instance.addToCollection(collectionID, files);
       }
-      RemoteSyncService.instance.sync(silently: true);
+      unawaited(RemoteSyncService.instance.sync(silently: true));
       await dialog?.hide();
       return true;
     } catch (e, s) {
@@ -214,11 +216,11 @@ extension CollectionFileActions on CollectionActions {
       return true;
     } catch (e, s) {
       logger.severe(e, s);
-      showShortToast(
-        context,
-        markAsFavorite
-            ? S.of(context).sorryCouldNotAddToFavorites
-            : S.of(context).sorryCouldNotRemoveFromFavorites,
+        showShortToast(
+          context,
+          markAsFavorite
+              ? S.of(context).sorryCouldNotAddToFavorites
+              : S.of(context).sorryCouldNotRemoveFromFavorites,
       );
     } finally {
       await dialog.hide();

--- a/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -115,7 +115,7 @@ class CollectionActions {
       S.of(context).creatingLink,
       isDismissible: true,
     );
-    dialog.show();
+    await dialog.show();
     try {
       // create album with emptyName, use collectionCreationTime on UI to
       // show name
@@ -143,10 +143,10 @@ class CollectionActions {
       await collectionsService.addToCollection(collection.id, files);
       logger.finest("creating public link for the newly created album");
       await CollectionsService.instance.createShareUrl(collection);
-      dialog.hide();
+      await dialog.hide();
       return collection;
     } catch (e, s) {
-      dialog.hide();
+      await dialog.hide();
       await showGenericErrorDialog(context: context, error: e);
       logger.severe("Failing to create link for selected files", e, s);
     }
@@ -467,9 +467,7 @@ class CollectionActions {
     }
 
     if (!isCollectionOwner && split.ownedByOtherUsers.isNotEmpty) {
-      unawaited(
-        showShortToast(context, S.of(context).canOnlyRemoveFilesOwnedByYou),
-      );
+      showShortToast(context, S.of(context).canOnlyRemoveFilesOwnedByYou);
       return;
     }
 

--- a/lib/ui/actions/file/file_actions.dart
+++ b/lib/ui/actions/file/file_actions.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/cupertino.dart";
 import "package:modal_bottom_sheet/modal_bottom_sheet.dart";
 import "package:photos/generated/l10n.dart";

--- a/lib/ui/collections/album/row_item.dart
+++ b/lib/ui/collections/album/row_item.dart
@@ -189,6 +189,7 @@ class AlbumRowItemWidget extends StatelessWidget {
       ),
       onTap: () async {
         final thumbnail = await CollectionsService.instance.getCover(c);
+        // ignore: unawaited_futures
         routeToPage(
           context,
           CollectionPage(

--- a/lib/ui/collections/album/vertical_list.dart
+++ b/lib/ui/collections/album/vertical_list.dart
@@ -120,7 +120,7 @@ class AlbumVerticalListWidget extends StatelessWidget {
       }
     } else {
       Navigator.pop(context);
-      await showToast(
+      showToast(
         context,
         S.of(context).createAlbumActionHint,
       );

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -400,13 +400,11 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
           : await _billingService.cancelStripeSubscription();
       await _fetchSub();
     } catch (e) {
-      unawaited(
-        showShortToast(
-          context,
-          isAutoRenewDisabled
-              ? S.of(context).failedToRenew
-              : S.of(context).failedToCancel,
-        ),
+      showShortToast(
+        context,
+        isAutoRenewDisabled
+            ? S.of(context).failedToRenew
+            : S.of(context).failedToCancel,
       );
     }
     await _dialog.hide();

--- a/lib/ui/settings/backup/backup_section_widget.dart
+++ b/lib/ui/settings/backup/backup_section_widget.dart
@@ -225,7 +225,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
         showShortToast(
           context,
           S.of(context).remindToEmptyEnteTrash,
-        ).ignore();
+        );
       },
     );
   }

--- a/lib/ui/settings/debug_section_widget.dart
+++ b/lib/ui/settings/debug_section_widget.dart
@@ -50,7 +50,7 @@ class DebugSectionWidget extends StatelessWidget {
           trailingIconIsMuted: true,
           onTap: () async {
             await LocalSyncService.instance.resetLocalSync();
-            showShortToast(context, "Done").ignore();
+            showShortToast(context, "Done");
           },
         ),
         sectionOptionSpacing,
@@ -64,7 +64,7 @@ class DebugSectionWidget extends StatelessWidget {
           onTap: () async {
             await IgnoredFilesService.instance.reset();
             SyncService.instance.sync().ignore();
-            showShortToast(context, "Done").ignore();
+            showShortToast(context, "Done");
           },
         ),
         sectionOptionSpacing,

--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -279,7 +279,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
       }
       await UserService.instance.updateEmailMFA(isEnabled);
     } catch (e) {
-      showToast(context, S.of(context).somethingWentWrong).ignore();
+      showToast(context, S.of(context).somethingWentWrong);
     }
   }
 }

--- a/lib/ui/tabs/shared/empty_state.dart
+++ b/lib/ui/tabs/shared/empty_state.dart
@@ -139,7 +139,7 @@ class OutgoingAlbumEmptyState extends StatelessWidget {
             labelText: S.of(context).shareYourFirstAlbum,
             icon: Icons.add,
             onTap: () async {
-              await showToast(
+              showToast(
                 context,
                 S.of(context).shareAlbumHint,
               );

--- a/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -502,11 +502,9 @@ class _FileSelectionActionsWidgetState
 
   Future<void> _onCreatedSharedLinkClicked() async {
     if (split.ownedByCurrentUser.isEmpty) {
-      unawaited(
-        showShortToast(
-          context,
-          S.of(context).canOnlyCreateLinkForFilesOwnedByYou,
-        ),
+      showShortToast(
+        context,
+        S.of(context).canOnlyCreateLinkForFilesOwnedByYou,
       );
       return;
     }
@@ -570,7 +568,7 @@ class _FileSelectionActionsWidgetState
       final String url =
           "${_cachedCollectionForSharedLink!.publicURLs?.first?.url}#$collectionKey";
       await Clipboard.setData(ClipboardData(text: url));
-      unawaited(showShortToast(context, S.of(context).linkCopiedToClipboard));
+      showShortToast(context, S.of(context).linkCopiedToClipboard);
     }
   }
 

--- a/lib/ui/viewer/file/zoomable_image.dart
+++ b/lib/ui/viewer/file/zoomable_image.dart
@@ -22,7 +22,6 @@ import 'package:photos/ui/common/loading_widget.dart';
 import 'package:photos/utils/file_util.dart';
 import 'package:photos/utils/image_util.dart';
 import 'package:photos/utils/thumbnail_util.dart';
-import "package:photos/utils/toast_util.dart";
 
 class ZoomableImage extends StatefulWidget {
   final EnteFile photo;
@@ -262,12 +261,6 @@ class _ZoomableImageState extends State<ZoomableImage>
     final bool shouldFixPosition = previewImageProvider != null && _isZooming;
     ImageInfo? finalImageInfo;
     if (shouldFixPosition) {
-      if (kDebugMode) {
-        showToast(
-          context,
-          'Updating photo scale zooming and scale: ${_photoViewController.scale}',
-        ).ignore();
-      }
       final prevImageInfo = await getImageInfo(previewImageProvider);
       finalImageInfo = await getImageInfo(finalImageProvider);
       final scale = _photoViewController.scale! /
@@ -303,9 +296,6 @@ class _ZoomableImageState extends State<ZoomableImage>
     if (h != enteFile.height || w != enteFile.width) {
       final logMessage =
           'Updating aspect ratio for from ${enteFile.height}x${enteFile.width} to ${h}x$w';
-      if (kDebugMode && (enteFile.height != 0 || enteFile.width != 0)) {
-        showToast(context, logMessage).ignore();
-      }
       _logger.info(logMessage);
       await FileMagicService.instance.updatePublicMagicMetadata([
         enteFile,

--- a/lib/ui/viewer/file_details/favorite_widget.dart
+++ b/lib/ui/viewer/file_details/favorite_widget.dart
@@ -79,11 +79,9 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
               } catch (e, s) {
                 _logger.severe(e, s);
                 hasError = true;
-                unawaited(
-                  showToast(
-                    context,
-                    S.of(context).sorryCouldNotRemoveFromFavorites,
-                  ),
+                showToast(
+                  context,
+                  S.of(context).sorryCouldNotRemoveFromFavorites,
                 );
               }
             }

--- a/lib/ui/viewer/gallery/gallery.dart
+++ b/lib/ui/viewer/gallery/gallery.dart
@@ -141,7 +141,7 @@ class GalleryState extends State<Gallery> {
       // todo: Assign ID to Gallery and fire generic event with ID &
       //  target index/date
       if (mounted && event.selectedIndex == 0) {
-        _itemScroller.scrollTo(
+        await _itemScroller.scrollTo(
           index: 0,
           duration: const Duration(milliseconds: 150),
         );

--- a/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -131,12 +131,10 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
     if (galleryType != GalleryType.ownedCollection &&
         galleryType != GalleryType.hiddenOwnedCollection &&
         galleryType != GalleryType.quickLink) {
-      unawaited(
-        showToast(
-          context,
-          'Type of galler $galleryType is not supported for '
-          'rename',
-        ),
+      showToast(
+        context,
+        'Type of galler $galleryType is not supported for '
+        'rename',
       );
 
       return;
@@ -269,7 +267,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
           showToast(
             context,
             S.of(context).remindToEmptyDeviceTrash,
-          ).ignore();
+          );
         }
       },
     );
@@ -614,7 +612,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
                 context,
               );
             } else {
-              unawaited(showToast(context, S.of(context).somethingWentWrong));
+              showToast(context, S.of(context).somethingWentWrong);
             }
           },
         ),

--- a/lib/ui/viewer/gallery/hooks/add_photos_sheet.dart
+++ b/lib/ui/viewer/gallery/hooks/add_photos_sheet.dart
@@ -216,7 +216,7 @@ class AddPhotosPhotoWidget extends StatelessWidget {
             },
           );
         } else {
-          showErrorDialog(
+          await showErrorDialog(
             context,
             context.l10n.oops,
             context.l10n.somethingWentWrong + (kDebugMode ? "\n$e" : ""),

--- a/lib/ui/viewer/search/result/go_to_map_widget.dart
+++ b/lib/ui/viewer/search/result/go_to_map_widget.dart
@@ -22,6 +22,7 @@ class GoToMapWidget extends StatelessWidget {
       onTap: () async {
         final bool result = await requestForMapEnable(context);
         if (result) {
+          // ignore: unawaited_futures
           Navigator.of(context).push(
             MaterialPageRoute(
               builder: (context) => MapScreen(

--- a/lib/ui/viewer/search/tab_empty_state.dart
+++ b/lib/ui/viewer/search/tab_empty_state.dart
@@ -35,6 +35,7 @@ class SearchTabEmptyState extends StatelessWidget {
               labelText: S.of(context).addYourPhotosNow,
               icon: Icons.arrow_forward_outlined,
               onTap: () async {
+                // ignore: unawaited_futures
                 routeToPage(
                   context,
                   BackupFolderSelectionPage(

--- a/lib/utils/delete_file_util.dart
+++ b/lib/utils/delete_file_util.dart
@@ -127,9 +127,9 @@ Future<void> deleteFilesFromEverywhere(
       ),
     );
     if (hasLocalOnlyFiles && Platform.isAndroid) {
-      await showShortToast(context, S.of(context).filesDeleted);
+      showShortToast(context, S.of(context).filesDeleted);
     } else {
-      await showShortToast(context, S.of(context).movedToTrash);
+      showShortToast(context, S.of(context).movedToTrash);
     }
   }
   if (uploadedFilesToBeTrashed.isNotEmpty) {

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -105,6 +105,7 @@ class FileUploader {
         );
         _logger.info("BG task was found dead, cleared all locks");
       }
+      // ignore: unawaited_futures
       _pollBackgroundUploadStatus();
     }
     Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) {

--- a/lib/utils/file_util.dart
+++ b/lib/utils/file_util.dart
@@ -165,9 +165,10 @@ Future<File?> getFileFromServer(
         },
       );
     }
-    downloadFuture.then((downloadedFile) {
+    // ignore: unawaited_futures
+    downloadFuture.then((downloadedFile) async {
       completer.complete(downloadedFile);
-      _fileDownloadsInProgress.remove(downloadID);
+      await _fileDownloadsInProgress.remove(downloadID);
       _progressCallbacks.remove(downloadID);
     });
   }
@@ -197,7 +198,7 @@ Future<File?> _getLivePhotoFromServer(
           _downloadLivePhoto(file, progressCallback: progressCallback);
     }
     final livePhoto = await _livePhotoDownloadsTracker[file.uploadedFileID];
-    _livePhotoDownloadsTracker.remove(downloadID);
+    await _livePhotoDownloadsTracker.remove(downloadID);
     if (livePhoto == null) {
       return null;
     }

--- a/lib/utils/magic_util.dart
+++ b/lib/utils/magic_util.dart
@@ -116,7 +116,7 @@ Future<void> changeSortOrder(
     );
   } catch (e, s) {
     _logger.severe("failed to update collection visibility", e, s);
-    unawaited(showShortToast(context, S.of(context).somethingWentWrong));
+    showShortToast(context, S.of(context).somethingWentWrong);
     rethrow;
   }
 }
@@ -136,7 +136,7 @@ Future<void> updateOrder(
     );
   } catch (e, s) {
     _logger.severe("failed to update order", e, s);
-    unawaited(showShortToast(context, S.of(context).somethingWentWrong));
+    showShortToast(context, S.of(context).somethingWentWrong);
     rethrow;
   }
 }
@@ -162,7 +162,7 @@ Future<void> changeCoverPhoto(
     );
   } catch (e, s) {
     _logger.severe("failed to update cover", e, s);
-    unawaited(showShortToast(context, S.of(context).somethingWentWrong));
+    showShortToast(context, S.of(context).somethingWentWrong);
     rethrow;
   }
 }
@@ -181,7 +181,7 @@ Future<bool> editTime(
     );
     return true;
   } catch (e) {
-    showShortToast(context, S.of(context).somethingWentWrong).ignore();
+    showShortToast(context, S.of(context).somethingWentWrong);
     return false;
   }
 }
@@ -240,7 +240,7 @@ Future<bool> editFileCaption(
     return true;
   } catch (e) {
     if (context != null) {
-      unawaited(showShortToast(context, S.of(context).somethingWentWrong));
+      showShortToast(context, S.of(context).somethingWentWrong);
     }
     return false;
   }
@@ -267,7 +267,7 @@ Future<void> _updatePublicMetadata(
     await FileMagicService.instance.updatePublicMagicMetadata(files, update);
     if (context != null) {
       if (showDoneToast) {
-        await showShortToast(context, S.of(context).done);
+        showShortToast(context, S.of(context).done);
       }
       await dialog?.hide();
     }

--- a/lib/utils/toast_util.dart
+++ b/lib/utils/toast_util.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -5,7 +6,7 @@ import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:photos/ente_theme_data.dart';
 
-Future showToast(
+void showToast(
   BuildContext context,
   String message, {
   toastLength = Toast.LENGTH_LONG,
@@ -13,14 +14,16 @@ Future showToast(
 }) async {
   if (Platform.isAndroid) {
     await Fluttertoast.cancel();
-    return Fluttertoast.showToast(
-      msg: message,
-      toastLength: toastLength,
-      gravity: ToastGravity.BOTTOM,
-      timeInSecForIosWeb: 1,
-      backgroundColor: Theme.of(context).colorScheme.toastBackgroundColor,
-      textColor: Theme.of(context).colorScheme.toastTextColor,
-      fontSize: 16.0,
+    unawaited(
+      Fluttertoast.showToast(
+        msg: message,
+        toastLength: toastLength,
+        gravity: ToastGravity.BOTTOM,
+        timeInSecForIosWeb: 1,
+        backgroundColor: Theme.of(context).colorScheme.toastBackgroundColor,
+        textColor: Theme.of(context).colorScheme.toastTextColor,
+        fontSize: 16.0,
+      ),
     );
   } else {
     EasyLoading.instance
@@ -29,18 +32,20 @@ Future showToast(
       ..textColor = Theme.of(context).colorScheme.toastTextColor
       ..userInteractions = true
       ..loadingStyle = EasyLoadingStyle.custom;
-    return EasyLoading.showToast(
-      message,
-      duration: Duration(
-        seconds:
-            (toastLength == Toast.LENGTH_LONG ? iosLongToastLengthInSec : 1),
+    unawaited(
+      EasyLoading.showToast(
+        message,
+        duration: Duration(
+          seconds:
+              (toastLength == Toast.LENGTH_LONG ? iosLongToastLengthInSec : 1),
+        ),
+        toastPosition: EasyLoadingToastPosition.bottom,
+        dismissOnTap: false,
       ),
-      toastPosition: EasyLoadingToastPosition.bottom,
-      dismissOnTap: false,
     );
   }
 }
 
-Future<void> showShortToast(context, String message) {
-  return showToast(context, message, toastLength: Toast.LENGTH_SHORT);
+void showShortToast(context, String message) {
+  showToast(context, message, toastLength: Toast.LENGTH_SHORT);
 }


### PR DESCRIPTION
Uses `// ignore: unawaited_futures` wherever adding `unawaited` hampered code readability, 

Also changes contract of APIs like `showToast` or `showShortToast`, where consumers never await on the outcome.