### PR TITLE
fix: error when logging out if magic search isn't enabled.

### DIFF
--- a/lib/core/configuration.dart
+++ b/lib/core/configuration.dart
@@ -27,6 +27,7 @@ import 'package:photos/services/favorites_service.dart';
 import 'package:photos/services/ignored_files_service.dart';
 import 'package:photos/services/memories_service.dart';
 import 'package:photos/services/search_service.dart';
+import "package:photos/services/semantic_search/semantic_search_service.dart";
 import 'package:photos/services/sync_service.dart';
 import 'package:photos/utils/crypto_util.dart';
 import 'package:photos/utils/file_uploader.dart';
@@ -157,7 +158,9 @@ class Configuration {
     _cachedToken = null;
     _secretKey = null;
     await FilesDB.instance.clearTable();
-    await ObjectBox.instance.clearTable();
+    SemanticSearchService.instance.hasInitialized
+        ? await ObjectBox.instance.clearTable()
+        : null;
     await CollectionsDB.instance.clearTable();
     await MemoriesDB.instance.clearTable();
     await PublicKeysDB.instance.clearTable();

--- a/lib/services/semantic_search/semantic_search_service.dart
+++ b/lib/services/semantic_search/semantic_search_service.dart
@@ -46,6 +46,8 @@ class SemanticSearchService {
   Future<List<EnteFile>>? _ongoingRequest;
   PendingQuery? _nextQuery;
 
+  get hasInitialized => _hasInitialized;
+
   Future<void> init() async {
     if (!LocalSettings.instance.hasEnabledMagicSearch()) {
       return;


### PR DESCRIPTION
## Description
`error: LateInitializationError: Field 'store' has not been initialized.`
If magic search was never enabled, `store` is left uninitialised and we try to access it before when logging out when calling 
`ObjectBox.instance.clearTable()`

## Test Plan

#### Tested the following cases
- Logging out when magic search was never enabled
- Logging out after enabling magic search.
- Logging out after enabling, disabling and then enabling magic search.
- Verified that `clearTable()` is getting called if magic search was ever enabled.
