### PR TITLE
wrap isar.clear() in isar.writeTxn() to avoid error

### DIFF
--- a/lib/db/embeddings_db.dart
+++ b/lib/db/embeddings_db.dart
@@ -23,7 +23,7 @@ class EmbeddingsDB {
   }
 
   Future<void> clearTable() async {
-    await _isar.clear();
+    await _isar.writeTxn(() => _isar.clear());
   }
 
   Future<List<Embedding>> getAll(Model model) async {


### PR DESCRIPTION
```
Failed to logout
⤷ type: IsarError
⤷ error: IsarError: Write operations require an explicit transaction. Wrap your code in isar.writeTxn()
```
