### PR TITLE
fix: range error when deleting last Memory from FullScreenMemory

### DIFF
--- a/lib/ui/home/memories/full_screen_memory.dart
+++ b/lib/ui/home/memories/full_screen_memory.dart
@@ -66,9 +66,14 @@ class _FullScreenMemoryDataUpdaterState
   }
 
   void removeCurrentMemory() {
-    setState(() {
-      widget.memories.removeAt(indexNotifier.value);
-    });
+    widget.memories.removeAt(indexNotifier.value);
+    if (widget.memories.isNotEmpty) {
+      setState(() {
+        if (widget.memories.length == indexNotifier.value) {
+          indexNotifier.value -= 1;
+        }
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
## Description

Fixes #1675

From `FullScreenMemory` screen, deleting memories other than the last one, `PageView`'s index and `indexNotifier.value` remains unchanged. But when deleting the last memory, `PageView`'s index decrements by 1 while `indexNotifier.value` remains unchanged. This was causing a `RangeError` when trying to access the last memory using the index in `indexNotifer.value`. This has been fixed. 

## Test Plan

Did testing by deleting memories from
- different indexes
- from last index
- when only one memory is left.
