### PR TITLE
Remove from album bug

### DIFF
--- a/lib/models/file/file.dart
+++ b/lib/models/file/file.dart
@@ -332,4 +332,71 @@ class EnteFile {
     // todo: Neeraj: 19thJuly'22: evaluate and add fileHash as the key?
     return localID ?? uploadedFileID?.toString() ?? generatedID.toString();
   }
+
+  EnteFile copyWith({
+    int? generatedID,
+    int? uploadedFileID,
+    int? ownerID,
+    int? collectionID,
+    String? localID,
+    String? title,
+    String? deviceFolder,
+    int? creationTime,
+    int? modificationTime,
+    int? updationTime,
+    int? addedTime,
+    Location? location,
+    FileType? fileType,
+    int? fileSubType,
+    int? duration,
+    String? exif,
+    String? hash,
+    int? metadataVersion,
+    String? encryptedKey,
+    String? keyDecryptionNonce,
+    String? fileDecryptionHeader,
+    String? thumbnailDecryptionHeader,
+    String? metadataDecryptionHeader,
+    int? fileSize,
+    String? mMdEncodedJson,
+    int? mMdVersion,
+    MagicMetadata? magicMetadata,
+    String? pubMmdEncodedJson,
+    int? pubMmdVersion,
+    PubMagicMetadata? pubMagicMetadata,
+  }) {
+    return EnteFile()
+      ..generatedID = generatedID ?? this.generatedID
+      ..uploadedFileID = uploadedFileID ?? this.uploadedFileID
+      ..ownerID = ownerID ?? this.ownerID
+      ..collectionID = collectionID ?? this.collectionID
+      ..localID = localID ?? this.localID
+      ..title = title ?? this.title
+      ..deviceFolder = deviceFolder ?? this.deviceFolder
+      ..creationTime = creationTime ?? this.creationTime
+      ..modificationTime = modificationTime ?? this.modificationTime
+      ..updationTime = updationTime ?? this.updationTime
+      ..addedTime = addedTime ?? this.addedTime
+      ..location = location ?? this.location
+      ..fileType = fileType ?? this.fileType
+      ..fileSubType = fileSubType ?? this.fileSubType
+      ..duration = duration ?? this.duration
+      ..exif = exif ?? this.exif
+      ..hash = hash ?? this.hash
+      ..metadataVersion = metadataVersion ?? this.metadataVersion
+      ..encryptedKey = encryptedKey ?? this.encryptedKey
+      ..keyDecryptionNonce = keyDecryptionNonce ?? this.keyDecryptionNonce
+      ..fileDecryptionHeader = fileDecryptionHeader ?? this.fileDecryptionHeader
+      ..thumbnailDecryptionHeader =
+          thumbnailDecryptionHeader ?? this.thumbnailDecryptionHeader
+      ..metadataDecryptionHeader =
+          metadataDecryptionHeader ?? this.metadataDecryptionHeader
+      ..fileSize = fileSize ?? this.fileSize
+      ..mMdEncodedJson = mMdEncodedJson ?? this.mMdEncodedJson
+      ..mMdVersion = mMdVersion ?? this.mMdVersion
+      ..magicMetadata = magicMetadata ?? this.magicMetadata
+      ..pubMmdEncodedJson = pubMmdEncodedJson ?? this.pubMmdEncodedJson
+      ..pubMmdVersion = pubMmdVersion ?? this.pubMmdVersion
+      ..pubMagicMetadata = pubMagicMetadata ?? this.pubMagicMetadata;
+  }
 }

--- a/lib/ui/actions/collection/collection_file_actions.dart
+++ b/lib/ui/actions/collection/collection_file_actions.dart
@@ -122,7 +122,7 @@ extension CollectionFileActions on CollectionActions {
         for (final file in selectedFiles!) {
           EnteFile? currentFile;
           if (file.uploadedFileID != null) {
-            currentFile = file;
+            currentFile = file.copyWith();
           } else if (file.generatedID != null) {
             // when file is not uploaded, refresh the state from the db to
             // ensure we have latest upload status for given file before
@@ -216,11 +216,11 @@ extension CollectionFileActions on CollectionActions {
       return true;
     } catch (e, s) {
       logger.severe(e, s);
-        showShortToast(
-          context,
-          markAsFavorite
-              ? S.of(context).sorryCouldNotAddToFavorites
-              : S.of(context).sorryCouldNotRemoveFromFavorites,
+      showShortToast(
+        context,
+        markAsFavorite
+            ? S.of(context).sorryCouldNotAddToFavorites
+            : S.of(context).sorryCouldNotRemoveFromFavorites,
       );
     } finally {
       await dialog.hide();

--- a/lib/ui/viewer/gallery/collection_page.dart
+++ b/lib/ui/viewer/gallery/collection_page.dart
@@ -31,8 +31,6 @@ class CollectionPage extends StatelessWidget {
 
   final _selectedFiles = SelectedFiles();
 
-  final GlobalKey shareButtonKey = GlobalKey();
-
   @override
   Widget build(BuildContext context) {
     if (hasVerifiedLock == false && c.collection.isHidden()) {


### PR DESCRIPTION
## Description

Fixes #1657

When adding a file from one collection to another, we do this

https://github.com/ente-io/photos-app/blob/4bddd24d6380d71f384144999c28ef9c9760226a/lib/ui/actions/collection/collection_file_actions.dart#L139

If we assign `currentFile = file`, it's just passing the reference of the `file` object to `currentFile`. This `file` is then now used both the `from` and `to` collections (when adding to a collection). So for the `file` in the `from` collection, it will have a different `collectionID` than it's collection.

To fix this, instead of passing a reference of `file`, create a new object. In this way, the original `file` object from the `from` collection is not modified and a copy of it is modified instead. 