### PR TITLE
fix: incorrect number of selected files on selecting all from a grid after deleting items from it

### DIFF
--- a/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
+++ b/lib/ui/viewer/gallery/component/group/lazy_group_gallery.dart
@@ -57,7 +57,6 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
   late Logger _logger;
 
   late List<EnteFile> _files;
-  Set<EnteFile>? _filesAsSet;
   late StreamSubscription<FilesUpdatedEvent>? _reloadEventSubscription;
   late StreamSubscription<int> _currentIndexSubscription;
   bool? _shouldRender;
@@ -65,7 +64,8 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
   @override
   void initState() {
     super.initState();
-    _areAllFromGroupSelectedNotifier = ValueNotifier(_areAllFromGroupSelected());
+    _areAllFromGroupSelectedNotifier =
+        ValueNotifier(_areAllFromGroupSelected());
 
     widget.selectedFiles?.addListener(_selectedFilesListener);
     _showSelectAllButtonNotifier = ValueNotifier(widget.showSelectAllByDefault);
@@ -89,11 +89,6 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
         });
       }
     });
-  }
-
-  Set<EnteFile> get _setOfFiles {
-    _filesAsSet ??= _files.toSet();
-    return _filesAsSet!;
   }
 
   bool _areAllFromGroupSelected() {
@@ -226,7 +221,7 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
                               ),
                               onTap: () {
                                 widget.selectedFiles?.toggleGroupSelection(
-                                  _setOfFiles,
+                                  _files.toSet(),
                                 );
                               },
                             );
@@ -256,7 +251,7 @@ class _LazyGroupGalleryState extends State<LazyGroupGallery> {
   void _selectedFilesListener() {
     if (widget.selectedFiles == null) return;
     _areAllFromGroupSelectedNotifier.value =
-        widget.selectedFiles!.files.containsAll(_setOfFiles);
+        widget.selectedFiles!.files.containsAll(_files.toSet());
 
     //Can remove this if we decide to show select all by default for all galleries
     if (widget.selectedFiles!.files.isEmpty && !widget.showSelectAllByDefault) {


### PR DESCRIPTION
## Description

Not updating `_filesAsSet` when updating files in group, like when deleting was the cause of this bug. Creating a new set (`O(n)`) on every selection fixes this issue.

Checked impact on performance and it's well within limits for a group of 7500 items, no possibility of jank.

## Test Plan

No possibility of new bugs, tested for drops in performance. 
