### PR TITLE
fix: stop playing video when navigating to it's album from file info

### DIFF
--- a/lib/events/pause_video_event.dart
+++ b/lib/events/pause_video_event.dart
@@ -1,0 +1,3 @@
+import "package:photos/events/event.dart";
+
+class PauseVideoEvent extends Event {}

--- a/lib/ui/viewer/file/video_widget_new.dart
+++ b/lib/ui/viewer/file/video_widget_new.dart
@@ -7,6 +7,8 @@ import "package:logging/logging.dart";
 import "package:media_kit/media_kit.dart";
 import "package:media_kit_video/media_kit_video.dart";
 import "package:photos/core/constants.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/events/pause_video_event.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
@@ -43,6 +45,7 @@ class _VideoWidgetNewState extends State<VideoWidgetNew>
   final _progressNotifier = ValueNotifier<double?>(null);
   late StreamSubscription<bool> playingStreamSubscription;
   bool _isAppInFG = true;
+  late StreamSubscription<PauseVideoEvent> pauseVideoSubscription;
 
   @override
   void initState() {
@@ -83,6 +86,10 @@ class _VideoWidgetNewState extends State<VideoWidgetNew>
         widget.playbackCallback!(event);
       }
     });
+
+    pauseVideoSubscription = Bus.instance.on<PauseVideoEvent>().listen((event) {
+      player.pause();
+    });
   }
 
   @override
@@ -96,6 +103,7 @@ class _VideoWidgetNewState extends State<VideoWidgetNew>
 
   @override
   void dispose() {
+    pauseVideoSubscription.cancel();
     removeCallBack(widget.file);
     _progressNotifier.dispose();
     WidgetsBinding.instance.removeObserver(this);

--- a/lib/ui/viewer/file_details/albums_item_widget.dart
+++ b/lib/ui/viewer/file_details/albums_item_widget.dart
@@ -1,6 +1,8 @@
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
+import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
+import "package:photos/events/pause_video_event.dart";
 import "package:photos/generated/l10n.dart";
 import 'package:photos/models/collection/collection.dart';
 import 'package:photos/models/collection/collection_items.dart';
@@ -87,6 +89,7 @@ class AlbumsItemWidget extends StatelessWidget {
               if (c.isHidden()) {
                 return;
               }
+              Bus.instance.fire(PauseVideoEvent());
               routeToPage(
                 context,
                 CollectionPage(


### PR DESCRIPTION
## Description

Thought of multiple ways to fix this. Found firing an event and listening to it the least complicated way to get this done because of how the widget tree is structured. 

One obvious workaround was to use `VisibilityDetector` on the `VideoWidgetNew` but it has a limitation. When a new screen is pushed, visibility doesn't change as we expect it to.
