### PR TITLE
Update release-action in manual build to use Node20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           path: build/app/outputs/flutter-apk/sha256sum
 
       # Create a pre-release
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@v1.14.0
         with:
           artifacts: "build/app/outputs/flutter-apk/ente.apk,build/app/outputs/flutter-apk/sha256sum"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to get manual build action working again, I think we should update the used release-action to the latest version that uses Node20: https://github.com/ncipollo/release-action/releases/tag/v1.14.0