### PR TITLE
Clear embeddings for files that no longer exist locally

### DIFF
--- a/lib/db/embeddings_db.dart
+++ b/lib/db/embeddings_db.dart
@@ -48,6 +48,19 @@ class EmbeddingsDB {
     return await _isar.embeddings.filter().updationTimeEqualTo(null).findAll();
   }
 
+  Future<void> deleteEmbeddings(List<int> fileIDs) async {
+    await _isar.writeTxn(() async {
+      final embeddings = <Embedding>[];
+      for (final fileID in fileIDs) {
+        embeddings.addAll(
+          await _isar.embeddings.filter().fileIDEqualTo(fileID).findAll(),
+        );
+      }
+      await _isar.embeddings.deleteAll(embeddings.map((e) => e.id).toList());
+      Bus.instance.fire(EmbeddingUpdatedEvent());
+    });
+  }
+
   Future<void> deleteAllForModel(Model model) async {
     await _isar.writeTxn(() async {
       final embeddings =

--- a/lib/services/machine_learning/semantic_search/embedding_store.dart
+++ b/lib/services/machine_learning/semantic_search/embedding_store.dart
@@ -53,12 +53,21 @@ class EmbeddingStore {
     final fileMap = await FilesDB.instance
         .getFilesFromIDs(pendingItems.map((e) => e.fileID).toList());
     _logger.info("Pushing ${pendingItems.length} embeddings");
+    final deletedEntries = <int>[];
     for (final item in pendingItems) {
       try {
-        await _pushEmbedding(fileMap[item.fileID]!, item);
+        final file = fileMap[item.fileID];
+        if (file != null) {
+          await _pushEmbedding(file, item);
+        } else {
+          deletedEntries.add(item.fileID);
+        }
       } catch (e, s) {
         _logger.severe(e, s);
       }
+    }
+    if (deletedEntries.isNotEmpty) {
+      await EmbeddingsDB.instance.deleteEmbeddings(deletedEntries);
     }
   }
 

--- a/lib/services/machine_learning/semantic_search/semantic_search_service.dart
+++ b/lib/services/machine_learning/semantic_search/semantic_search_service.dart
@@ -243,14 +243,22 @@ class SemanticSearchService {
 
     final ignoredCollections =
         CollectionsService.instance.getHiddenCollectionIds();
+    final deletedEntries = <int>[];
     for (final result in queryResults) {
       final file = filesMap[result.id];
       if (file != null && !ignoredCollections.contains(file.collectionID)) {
-        results.add(filesMap[result.id]!);
+        results.add(file);
+      }
+      if (file == null) {
+        deletedEntries.add(result.id);
       }
     }
 
     _logger.info(results.length.toString() + " results");
+
+    if (deletedEntries.isNotEmpty) {
+      unawaited(EmbeddingsDB.instance.deleteEmbeddings(deletedEntries));
+    }
 
     return results;
   }


### PR DESCRIPTION
This runs lazily either when search results are computed, or when we try to push embeddings.

p.s. Running this lazily wasn't a choice, I'd have preferred to run them in one shot at a single place. But we currently don't pull all embeddings and match them to files (to save on compute). So taking the path of least resistance for now.